### PR TITLE
Add/update registers and fields about MSI support and fix descriptions in Section 3.5.1

### DIFF
--- a/appendix_a4.adoc
+++ b/appendix_a4.adoc
@@ -2,5 +2,5 @@
 [Appendix_A4]
 == A4: Message-Signaled Interrupts (MSI)
 
-In systems built with an Incoming Message-Signaled Interrupt Controller (IMSIC), the IOPMP can trigger message-signaled interrupts (MSI) by writing a word of data to a specific address. The address is specified by *ERR_MSIADR* and *ERR_MSIADRH* (implemented only when *HWCFG0.addrh_en*=1), while the content to write is stored in the field msidata in the register *ERR_CFG*. The *ERR_MSIADR*, *ERR_MSIADRH*, and *ERR_CFG* are locked by the *ERR_CFG.l*.
-The bit *ERR_CFG.msi_en* indicates whether the IOPMP triggers MSI. *ERR_MSIADR*, *ERR_MSIADRH*, and *ERR_CFG.msidata* are not available when *ERR_CFG.msi_en* = 0. The bit can be programmable or hardwired.
+In systems built with an Incoming Message-Signaled Interrupt Controller (IMSIC), the IOPMP can trigger message-signaled interrupts (MSI) by writing a word of data to a specific address. The address is specified by *ERR_MSIADDR* and *ERR_MSIADDRH* (implemented only when *HWCFG0.addrh_en*=1), while the content to write is stored in the field msidata in the register *ERR_CFG*. The *ERR_MSIADDR*, *ERR_MSIADDRH*, and *ERR_CFG* are locked by the *ERR_CFG.l*.
+The bit *ERR_CFG.msi_en* indicates whether the IOPMP triggers MSI. *ERR_MSIADDR*, *ERR_MSIADDRH*, and *ERR_CFG.msidata* are not available when *ERR_CFG.msi_en* = 0. The bit can be programmable or hardwired.

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -65,7 +65,7 @@ The term 'lock' refers to a hardware feature that renders one or more fields or 
 
 [#SECTION_3_5_1]
 ==== SRCMD Table Protection
-The two fields *MDLCK.md* and *MDLCKH.mdh* have 63 bits together. Every bit is used to lock the association bits with a memory domain in the SRCMD table. In Format 0,  for MD _m_&#x2264;31, *MDLCK.md[_m_]* looks *SRCMD(_s_).md[_m_]* for all existing RRID _s_. In Format 1, there is no *MDLCK*. In Format 2, *MDLCK.md[_m_]* locks both *SRCMD_PERM(_m_).r* and *SRCMD_PERM(_m_).w*. For MD _m_&#x2265;32, one should use *MDLCKH.mdh* to lock corresponding bits.
+The two fields *MDLCK.md* and *MDLCKH.mdh* have 63 bits together. Every bit is used to lock the association bits with a memory domain in the SRCMD table. In Format 0,  for MD _m_&#x2264;31, *MDLCK.md[_m_]* locks *SRCMD(_s_).md[_m_]* for all existing RRID _s_. In Format 1, there is no *MDLCK*. In Format 2, *MDLCK.md[_m_]* locks both *SRCMD_PERM(_m_)* and *SRCMD_PERMH(_m_)*. For MD _m_&#x2265;32, one should use *MDLCKH.mdh* to lock corresponding bits.
 
 Bit *MDLCK.l* is a sticky to 1 and indicates if *MDLCK* and *MDLCKH* are locked.
 

--- a/chapter5.adoc
+++ b/chapter5.adoc
@@ -6,7 +6,7 @@ If an optional register is not implemented, the behavior is implementation-depen
 |===
 |OFFSET |Register |Description
 
-.19+|0x0000  2+|{set:cellbgcolor:#D3D3D3} INFO
+.20+|0x0000  2+|{set:cellbgcolor:#D3D3D3} INFO
 |{set:cellbgcolor:#FFFFFF} VERSION |Indicates the specification and the IP vendor.
 |{set:cellbgcolor:#FFFFFF} IMPLEMENTATION | Indicates the implementation version.
 |{set:cellbgcolor:#FFFFFF} HWCFG0~2 |Indicate the configurations of current IOPMP instance.
@@ -27,6 +27,7 @@ If an optional register is not implemented, the behavior is implementation-depen
 |ERR_REQID    
 |{set:cellbgcolor:#FFFFFF} ERR_REQADDR/ERR_REQADDRH
 |ERR_MFR| (Optional) To retrieve which RRIDs make subsequent violations.
+|ERR_MSIADDR/ERR_MSIADDRH| (Optional) The address to trigger MSI.
 |ERR_USER(0:7) | (Optional) User-defined violation information.
 
 .2+|0x0800 2+|{set:cellbgcolor:#D3D3D3} MDCFG Table,  _m_ = 0...*HWCFG0.md_num*-1

--- a/chapter5.adoc
+++ b/chapter5.adoc
@@ -118,7 +118,7 @@ Please refer to <<#SECTION_3_2, SRCMD Table Formats>> for details.
 
 *md_entry_num* is locked if *HWCFG0.enable* is 1.
 |md_num                         |29:24  |R      |IMP        |Indicate the supported number of MD in the instance
-|addrh_en                       |30     |R      |IMP        |Indicate if the IOPMP implements *ENTRY_ADDRH(_i_)*
+|addrh_en                       |30     |R      |IMP        |Indicate if the IOPMP implements *ENTRY_ADDRH(_i_)* and *ERR_MSIADDRH* if having
 |enable                         |31:31  |W1SS   |0          |Indicate if the IOPMP checks transactions by default. If it is implemented, it should be initial to 0 and sticky to 1. If it is not implemented, it should be wired to 1. *HWCFG0.md_entry_num* is locked if *enable* is 1.
 |===
 
@@ -245,16 +245,19 @@ h|Field                         |Bits       |R/W    |Default    |Description
 |===
 5+h|ERR_CFG{set:cellbgcolor:#D3D3D3}
 5+h|0x0060
-h|Field                         |Bits   |R/W    |Default    |Description
-|{set:cellbgcolor:#FFFFFF}l     |0:0    |W1SS   |0          |Lock fields to *ERR_CFG* register
-|{set:cellbgcolor:#FFFFFF}ie    |1:1    |RW     |0          |Enable the interrupt of the IOPMP rule violation.
-|{set:cellbgcolor:#FFFFFF}rs   |2:2    |WARL   |0     a| 
+h|Field                           |Bits   |R/W    |Default    |Description
+|{set:cellbgcolor:#FFFFFF}l       |0:0    |W1SS   |0          |Lock fields to *ERR_CFG* register
+|{set:cellbgcolor:#FFFFFF}ie      |1:1    |RW     |0          |Enable the interrupt of the IOPMP rule violation.
+|{set:cellbgcolor:#FFFFFF}rs      |2:2    |WARL   |0         a| 
 
 To suppress an error response on an IOPMP rule violation.
 
 * 0x0: respond an implementation-dependent error, such as a bus error
 * 0x1: respond a success with a pre-defined value to the initiator instead of an error
-|{set:cellbgcolor:#FFFFFF}rsv   |31:3  |ZERO   |0     | Must be zero on write, reserved for future
+|{set:cellbgcolor:#FFFFFF}msi_en  |3:3    |WARL   |IMP        | It indicates whether the IOPMP triggers MSI
+|{set:cellbgcolor:#FFFFFF}rsv1    |7:4    |ZERO   |0     | Must be zero on write, reserved for future
+|{set:cellbgcolor:#FFFFFF}msidata |18:8   |WARL   |IMP   | The data to trigger MSI
+|{set:cellbgcolor:#FFFFFF}rsv2    |31:19  |ZERO   |0     | Must be zero on write, reserved for future
 |===
 
 
@@ -334,6 +337,22 @@ h|Field                         |Bits       |R/W    |Default    |Description
 
 * 0x0 : no subsequent violation found
 * 0x1 : subsequent violation found
+|===
+
+[cols="<2,<1,<1,<1,<6",stripes=even]
+|===
+5+h|{set:cellbgcolor:#D3D3D3} ERR_MSIADDR
+5+h|0x0078
+h|Field                           |Bits       |R/W    |Default    |Description
+|{set:cellbgcolor:#FFFFFF}msiaddr |31:0       |WARL   |IMP        | The address to trigger MSI. For *HWCFG0.addrh_en*=0, it contains bits 33 to 2 of the address; otherwise, it contains bits 31 to 0. Available only if *ERR_CFG.msi_en*=1 
+|===
+
+[cols="<2,<1,<1,<1,<6",stripes=even]
+|===
+5+h|{set:cellbgcolor:#D3D3D3} ERR_MSIADDRH
+5+h|0x007C
+h|Field                            |Bits       |R/W    |Default    |Description
+|{set:cellbgcolor:#FFFFFF}msiaddrh |31:0       |WARL   |IMP        | The higher 32 bits of the address to trigger MSI. Available only if *HWCFG0.addrh_en*=1 and *ERR_CFG.msi_en*=1
 |===
 
 *ERR_USER(0:7)* are optional registers to provide users to define their own error capture information.


### PR DESCRIPTION
Rename ERR_MSIADR and ERR_MSIADRH to ERR_MSIADDR and ERR_MSIADDRH.
Add registers and fields about MSI support in Chapter 5.
Fix typo about SRCMD table format 0.
Fix description about MDLCK(m) in SRCMD table format 2. It should lock both SRCMD_PERM(_m_) and SRCMD_PERMH(_m_).