### PR TITLE
IOPMP Reference Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,18 @@
 *.pdf
+# Object files
+*.o
 
+# Libraries
+*.a
+
+# Executables
+*.exe
+*.out
+
+# Coverage Files
+*.gcno
+*.gcda
+
+# Binary Files
+iopmp_ref_model/bin/
+iopmp_ref_model/lib/

--- a/iopmp_ref_model/Makefile
+++ b/iopmp_ref_model/Makefile
@@ -4,15 +4,15 @@ SRC_DIR  := src
 VERIF    := verif
 TEST_DIR := $(VERIF)/tests
 LIB_DIR  := lib
-cov = 
-COVFLAGS = 
+cov =
+COVFLAGS =
 ifeq ($(cov), 1)
 COVFLAGS += -fprofile-arcs -ftest-coverage -lgcov --coverage
 endif
 
 # Compiler and flags
 CC := gcc
-CFLAGS := -Wall -Werror $(COVFLAGS) -I./include -Iverif/
+CFLAGS := -Wall -Werror $(COVFLAGS) -I./include -Iverif/ -fPIC
 LDFLAGS := -lm
 
 # Common source files
@@ -62,10 +62,16 @@ build: $(BIN_DIR) $(LIB_DIR)
 				$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt -c $$src -o $$obj_file; \
 				obj_files="$$obj_files $$obj_file"; \
 			done; \
-			ar rcD $(LIB_DIR)/$$model.a $$obj_files > /dev/null 2>&1; \
-			ranlib $(LIB_DIR)/$$model.a; \
-			$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt \
-				$(TEST_DIR)/$$source -L$(LIB_DIR) -l:$$model.a -o $(BIN_DIR)/$$model $(LDFLAGS); \
+			if [ -n "$(sharedLib)" ]; then \
+				$(CC) $$obj_files -shared -o $(LIB_DIR)/$$model.so; \
+				$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt \
+					$(TEST_DIR)/$$source -L$(LIB_DIR) -l:$$model.so -o $(BIN_DIR)/$$model $(LDFLAGS); \
+			else \
+				ar rcs $(LIB_DIR)/$$model.a $$obj_files > /dev/null 2>&1; \
+				ranlib $(LIB_DIR)/$$model.a; \
+				$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt \
+					$(TEST_DIR)/$$source -L$(LIB_DIR) -l:$$model.a -o $(BIN_DIR)/$$model $(LDFLAGS); \
+			fi; \
 			echo "Library and executable for $$model built successfully."; \
 			rm -f $$obj_files; \
 		done; \
@@ -85,10 +91,16 @@ build: $(BIN_DIR) $(LIB_DIR)
 			$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt -c $$src -o $$obj_file; \
 			obj_files="$$obj_files $$obj_file"; \
 		done; \
-		ar rcD $(LIB_DIR)/$(model).a $$obj_files > /dev/null 2>&1; \
-		ranlib $(LIB_DIR)/$(model).a; \
-		$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt \
+		if [ -n "$(sharedLib)" ]; then \
+			$(CC) $$obj_files -shared -o $(LIB_DIR)/$$model.so; \
+			$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt \
+				$(TEST_DIR)/$$source -L$(LIB_DIR) -l:$$model.so -o $(BIN_DIR)/$$model $(LDFLAGS); \
+		else \
+			ar rcs $(LIB_DIR)/$$model.a $$obj_files > /dev/null 2>&1; \
+			ranlib $(LIB_DIR)/$$model.a; \
+			$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt \
 				$(TEST_DIR)/$$source -L$(LIB_DIR) -l:$$model.a -o $(BIN_DIR)/$$model $(LDFLAGS); \
+		fi; \
 		echo "Library and executable for $(model) built successfully."; \
 		rm -f $$obj_files; \
 	fi
@@ -105,6 +117,39 @@ run:
 			echo "Binary $$binary not found. Did you build it?"; \
 		fi; \
 	done
+
+# Display usage information
+.PHONY: help
+
+help:
+	@echo "Usage: make [TARGET] [VARIABLE=value]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all           Build all models and run their binaries"
+	@echo "  build         Compile all models or a specific model"
+	@echo "                Use 'model=<model_name>' to specify a model"
+	@echo "  run           Run all compiled binaries"
+	@echo "                Ensure the models are built before running"
+	@echo "  clean         Remove all compiled binaries, libraries, and coverage files"
+	@echo "  help          Display this usage information"
+	@echo ""
+	@echo "Variables:"
+	@echo "  model=<model_name>    Build a specific model instead of all models"
+	@echo "                        Example: make build model=full_model"
+	@echo "  sharedLib=1           Build shared libraries instead of static ones"
+	@echo "  cov=1                 Enable code coverage during compilation"
+	@echo ""
+	@echo "Available Models:"
+	@echo "  full_model            SRCMD_FMT = 0, MDCFG_FMT = 0"
+	@echo "  rapid_k_model         SRCMD_FMT = 0, MDCFG_FMT = 1"
+	@echo "  dynamic_k_model       SRCMD_FMT = 0, MDCFG_FMT = 2"
+	@echo "  isolation_model       SRCMD_FMT = 1, MDCFG_FMT = 0"
+	@echo "  compact_k_model       SRCMD_FMT = 1, MDCFG_FMT = 1"
+	@echo "  unnamed_model_1       SRCMD_FMT = 1, MDCFG_FMT = 2"
+	@echo "  unnamed_model_2       SRCMD_FMT = 2, MDCFG_FMT = 0"
+	@echo "  unnamed_model_3       SRCMD_FMT = 2, MDCFG_FMT = 1"
+	@echo "  unnamed_model_4       SRCMD_FMT = 2, MDCFG_FMT = 2"
+	@echo ""
 
 # Clean the binary and library directories
 clean:

--- a/iopmp_ref_model/Makefile
+++ b/iopmp_ref_model/Makefile
@@ -1,0 +1,111 @@
+# Directories
+BIN_DIR  := bin
+SRC_DIR  := src
+VERIF    := verif
+TEST_DIR := $(VERIF)/tests
+LIB_DIR  := lib
+cov = 
+COVFLAGS = 
+ifeq ($(cov), 1)
+COVFLAGS += -fprofile-arcs -ftest-coverage -lgcov --coverage
+endif
+
+# Compiler and flags
+CC := gcc
+CFLAGS := -Wall -Werror $(COVFLAGS) -I./include -Iverif/
+LDFLAGS := -lm
+
+# Common source files
+COMMON_SOURCES := $(SRC_DIR)/iopmp_reg.c \
+				  $(SRC_DIR)/iopmp_interrupt.c \
+                  $(SRC_DIR)/iopmp_rule_analyzer.c \
+                  $(SRC_DIR)/iopmp_validate.c \
+                  $(SRC_DIR)/iopmp_error_capture.c \
+                  $(VERIF)/test_utils.c
+
+# Models and configurations
+MODELS := full_model:fullmodel.c:0:0 \
+          rapid_k_model:rapidmodel.c:0:1 \
+          dynamic_k_model:dynamicmodel.c:0:2 \
+          isolation_model:isolationmodel.c:1:0 \
+          compact_k_model:compactmodel.c:1:1 \
+          unnamed_model_1:unnamed_model_1.c:1:2 \
+          unnamed_model_2:unnamed_model_2.c:2:0 \
+          unnamed_model_3:unnamed_model_3.c:2:1 \
+          unnamed_model_4:unnamed_model_4.c:2:2
+
+# Targets
+.PHONY: all build run clean
+
+all: build run
+
+# Ensure the directories exist
+$(BIN_DIR):
+	mkdir -p $(BIN_DIR)
+
+$(LIB_DIR):
+	mkdir -p $(LIB_DIR)
+
+# Build all models into libraries and executables
+build: $(BIN_DIR) $(LIB_DIR)
+	@if [ -z "$(model)" ]; then \
+		echo "Building all models..."; \
+		for entry in $(MODELS); do \
+			model=$$(echo $$entry | cut -d':' -f1); \
+			source=$$(echo $$entry | cut -d':' -f2); \
+			srcmd_fmt=$$(echo $$entry | cut -d':' -f3); \
+			mdcfg_fmt=$$(echo $$entry | cut -d':' -f4); \
+			echo "Building library and executable for $$model..."; \
+			obj_files=""; \
+			for src in $(COMMON_SOURCES) $(TEST_DIR)/$$source; do \
+				obj_file=$$(basename $$src .c).o; \
+				$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt -c $$src -o $$obj_file; \
+				obj_files="$$obj_files $$obj_file"; \
+			done; \
+			ar rcD $(LIB_DIR)/$$model.a $$obj_files > /dev/null 2>&1; \
+			ranlib $(LIB_DIR)/$$model.a; \
+			$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt \
+				$(TEST_DIR)/$$source -L$(LIB_DIR) -l:$$model.a -o $(BIN_DIR)/$$model $(LDFLAGS); \
+			echo "Library and executable for $$model built successfully."; \
+			rm -f $$obj_files; \
+		done; \
+	else \
+		entry=$$(echo "$(MODELS)" | tr ' ' '\n' | grep -E "^$(model):"); \
+		if [ -z "$$entry" ]; then \
+			echo "Error: Model $(model) not found."; \
+			exit 1; \
+		fi; \
+		source=$$(echo $$entry | cut -d':' -f2); \
+		srcmd_fmt=$$(echo $$entry | cut -d':' -f3); \
+		mdcfg_fmt=$$(echo $$entry | cut -d':' -f4); \
+		echo "Building library and executable for $(model)..."; \
+		obj_files=""; \
+		for src in $(COMMON_SOURCES) $(TEST_DIR)/$$source; do \
+			obj_file=$$(basename $$src .c).o; \
+			$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt -c $$src -o $$obj_file; \
+			obj_files="$$obj_files $$obj_file"; \
+		done; \
+		ar rcD $(LIB_DIR)/$(model).a $$obj_files > /dev/null 2>&1; \
+		ranlib $(LIB_DIR)/$(model).a; \
+		$(CC) $(CFLAGS) -DSRCMD_FMT=$$srcmd_fmt -DMDCFG_FMT=$$mdcfg_fmt \
+				$(TEST_DIR)/$$source -L$(LIB_DIR) -l:$$model.a -o $(BIN_DIR)/$$model $(LDFLAGS); \
+		echo "Library and executable for $(model) built successfully."; \
+		rm -f $$obj_files; \
+	fi
+
+# Run all compiled binaries
+run:
+	@for model in $(MODELS); do \
+		target=$${model%%:*}; \
+		binary=$(BIN_DIR)/$$target; \
+		if [ -f $$binary ]; then \
+			echo "Running $$binary..."; \
+			$$binary; \
+		else \
+			echo "Binary $$binary not found. Did you build it?"; \
+		fi; \
+	done
+
+# Clean the binary and library directories
+clean:
+	rm -rf bin/ lib/ *.gcno *.gcda

--- a/iopmp_ref_model/README.md
+++ b/iopmp_ref_model/README.md
@@ -1,6 +1,6 @@
 # IOPMP Reference Model Documentation
 
-The **Input/Output Physical Memory Protection (IOPMP)** is a hardware component designed to control and validate accesses issued from bus initiators. It checks the validity of these accesses in real-time. The **IOPMP Reference Model** is developed in compliance with the **RISC-V IOPMP Specification Version 0.9.2-RC2 (November 2024)**. This model is currently in the development phase and will be updated with future specification revisions.
+The **Input/Output Physical Memory Protection (IOPMP)** is a hardware component designed to control and validate accesses issued from bus initiators. It checks the validity of these accesses in real-time. The **IOPMP Reference Model** is developed in compliance with the **RISC-V IOPMP Specification Version 0.8, 2025**. This model  will be updated with future specification revisions.
 
 ## IOPMP Model Overview
 
@@ -19,9 +19,7 @@ The IOPMP Reference Model includes several distinct configurations, each offerin
 | **Unnamed Model 4** | 2                   | 2             | Same as **Unnamed Model 3**, but the value of *k* is programmable. |
 
 ## Supported Features
-
-The **IOPMP Reference Model** incorporates all features as outlined in the **RISC-V IOPMP Specification Version 0.9.2-RC2 (November 2024)**. Key features include:
-
+The **IOPMP Reference Model** incorporates all IOPMP Models and each model can be configured based upon SRCMD_FMT and MDCFG_FMT flags at compilation time. All features outlined in the **RISC-V IOPMP Specification Version 0.8, 2025**. Key feature configuration parameters include:
 | **Feature**  | **Possible Values** | **Description**                                                                                                                                                                                                                    |
 | ------------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | TOR_EN             | 0/1                       | Indicates if Top-Of-Range (TOR) addressing mode is supported.<br />**0**: TOR not supported. <br />**1**: TOR supported                                                                                                      |
@@ -46,43 +44,46 @@ The **IOPMP Reference Model** incorporates all features as outlined in the **RIS
 | IMP_ERROR_REQID    | 0/1                       | Indicates if `ERR_REQID` is implemented. <br />**0**: Feature not supported. <br />**1**: Errored RRID and Entry num is recorded.                                                                                          |
 | IMP_MDLCK          | 0/1                       | Indicates if the Memory Domain Lock (MDLCK) feature is implemented.<br />**0**: Feature is not implemented<br />**1**: Memory domains can be locked.                                                                         |
 | REG_INTF_BUS_WIDTH | 4/8                       | Specifies the width (in bytes) of the register interface bus.<br />**4**: 4-byte width. <br />**8**: 8-byte width.                                                                                                           |
-| MSI_EN             | 0/1                       | Indicates if Messaged-Signal-Interrupts are supported.<br />**0:** MSI is not supported.<br />**1:** MSI can be generated.                                                                                                |
+| MSI_EN             | 0/1                       | Indicates if Messaged-Signal-Interrupts are supported.<br />**0:** MSI is not supported.<br />**1:** MSI can be generated.                                                                                                           |
+| SRC_ENFORCEMENT_EN             | 0/1                       | Indicates if Source Enforcement is enabled.<br />**0:** Source Enforcement is not enabled.<br />**1:** Source Enforcement is enabled.                                                                                                           |
+| IMP_RRIDSCP             | 0/1                       | Indicates if RRIDSCP register is implemented.<br />**0:** RRIDSCP register is not implemented.<br />**1:** RRIDSCP register is implemented.                                                                                                 |
+
 
 ## Reference Model Functions
 
 These functions are designed for use within a testbench to input stimuli and obtain responses from the respective models:
 
-1. **`int reset_iopmp()`**  
+1. **`int reset_iopmp(void)`**
    Resets the IOPMP registers to their default values. The function returns 0 if the reference model is successfully initialized.
 
-2. **`void write_register(uint16_t offset, reg_intf_dw data, uint8_t num_bytes)`**  
+2. **`void write_register(uint64_t offset, reg_intf_dw data, uint8_t num_bytes)`**
    Writes data to a memory-mapped register identified by the specified offset. The number of bytes written is specified by `num_bytes`. If the access is invalid, the write is ignored. The data type `reg_intf_dw` depends on the configuration in the `config.h` file (e.g., `uint32_t` for 4-byte width, `uint64_t` for 8-byte width).
 
-3. **`reg_intf_dw read_register(uint16_t offset, uint8_t num_bytes)`**  
+3. **`reg_intf_dw read_register(uint64_t offset, uint8_t num_bytes)`**
    Reads data from a memory-mapped register identified by the specified offset. The number of bytes to read is specified by `num_bytes`. If the access is invalid, the function returns zeros. The data type `reg_intf_dw` is dependent on the bus width defined in `config.h`.
-   
-4. **`int create_memory(uint8_t mem_gb)`**  
+
+4. **`int create_memory(uint8_t mem_gb)`**
    Allocates memory of the specified size in gigabytes. mem_gb is used for the size of the memory to allocate in gigabytes. It returns 0 if the memory allocation was successful, -1 otherwise.
 
-5. **`uint8_t read_memory(uint64_t addr, uint8_t size, char *data)`**  
+5. **`uint8_t read_memory(uint64_t addr, uint8_t size, uint64_t *data)`**
    Read data from a specific memory address. The param addr is the memory address from where the data should be read. The param size is the size of the data in bytes. The pram data is the pointer to the data for read. It returns 0 if the read was successful, BUS_ERROR if the address corresponds to a bus error.
 
-6. **`uint8_t write_memory(char *data, uint64_t addr, uint32_t size)`**  
+6. **`uint8_t write_memory(uint64_t *data, uint64_t addr, uint32_t size)`**
    This function writes data to a specific memory address, the param data indicates Pointer to the data to write, the param addr is the memory address where the data should be written and param size will be the size of the data in bytes. it returns 0 if the write was successful, BUS_ERROR if the address corresponds to a bus error.
 
-7. **`void configure_srcmd_n(uint8_t srcmd_reg, uint16_t srcmd_idx, reg_intf_dw data, uint8_t num_bytes)`**  
+7. **`void configure_srcmd_n(uint8_t srcmd_reg, uint16_t srcmd_idx, reg_intf_dw data, uint8_t num_bytes)`**
    This function is used for SRCMD Table Configurations. The param srcmd_reg could be SRCMD_EN, SRCMD_ENH, SRCMD_R, SRCMD_RH, SRCMD_W, SRCMD_WH. srcmd_idx could be any legal SRCMD table index, data contains the value that you want to write in this register. The number of bytes to write is specified by `num_bytes`. It could be 4-Byte write or 8-Byte Write.
 
-8. **`void configure_mdcfg_n(uint8_t md_idx, reg_intf_dw data, uint8_t num_bytes)`**  
+8. **`void configure_mdcfg_n(uint8_t md_idx, reg_intf_dw data, uint8_t num_bytes)`**
    This function is used for MDCFG Table Configurations. md_idx could be any legal MDCFG table index, data contains the value that you want to write in this register. The number of bytes to write is specified by `num_bytes`. It could be 4-Byte write or 8-Byte Write.
 
-9. **`void configure_entry_n(uint8_t entry_reg, uint64_t entry_idx, reg_intf_dw data, uint8_t num_bytes)`**  
+9. **`void configure_entry_n(uint8_t entry_reg, uint64_t entry_idx, reg_intf_dw data, uint8_t num_bytes)`**
    This function is used for Entry Table Configurations. entry_idx could be any legal Entry table index, data contains the value that you want to write in this register. The number of bytes to write is specified by `num_bytes`. It could be 4-Byte write or 8-Byte Write.
 
-10. **`void receiver_port(uint16_t rrid, uint64_t addr, uint32_t length, uint32_t size, perm_type_e perm, iopmp_trans_req_t *iopmp_trans_req)`**  
+10. **`void receiver_port(uint16_t rrid, uint64_t addr, uint32_t length, uint32_t size, perm_type_e perm, iopmp_trans_req_t *iopmp_trans_req)`**
    This function contains receiver port signals, that will be passed to the iopmp, where rrid is RRID Of the Bus Initiator, addr is Address to be checked, length is length Number of transfers, size is It should be 0 for 1-byte, 1 for 2-byte, 2 for 4-byte access, perm is the permissions required for this transcation, iopmp_trans_req is a pointer, pass it as it is.
 
-11. **`int error_record_chk(uint8_t err_type, uint8_t req_perm, uint64_t req_addr, bool err_rcd)`**  
+11. **`int error_record_chk(uint8_t err_type, uint8_t req_perm, uint64_t req_addr, bool err_rcd)`**
    This could be used to check the error record register data. err_type is the ype of Error, req_perm contains the Requested permissions, req_addr contains the requested address, err_rcd indicated if Set if error should be recorded
 
 ## **Compilation and Simulation of IOPMP Models**
@@ -92,20 +93,20 @@ The **IOPMP Reference Model** is written in C and requires a GCC compiler for co
 1. Adjust the `config.h` file as needed to customize IOPMP configurations.
 2. Use the following commands to compile:
 
-   - **Compile All Models**:  
+   - **Compile All Models**:
      ```bash
      make all
      ```
-   - **Compile Specific Models**:  
+   - **Compile Specific Models**:
      ```bash
-     make build model=full_model        # Full Model  
-     make build model=rapid_k_model     # Rapid-k Model  
-     make build model=dynamic_k_model   # Dynamic-k Model  
-     make build model=isolation_model   # Isolation Model  
-     make build model=compact_k_model   # Compact-k Model  
-     make build model=unnamed_model_1   # Unnamed Model 1  
-     make build model=unnamed_model_2   # Unnamed Model 2  
-     make build model=unnamed_model_3   # Unnamed Model 3  
+     make build model=full_model        # Full Model
+     make build model=rapid_k_model     # Rapid-k Model
+     make build model=dynamic_k_model   # Dynamic-k Model
+     make build model=isolation_model   # Isolation Model
+     make build model=compact_k_model   # Compact-k Model
+     make build model=unnamed_model_1   # Unnamed Model 1
+     make build model=unnamed_model_2   # Unnamed Model 2
+     make build model=unnamed_model_3   # Unnamed Model 3
      make build model=unnamed_model_4   # Unnamed Model 4
      ```
 

--- a/iopmp_ref_model/README.md
+++ b/iopmp_ref_model/README.md
@@ -1,0 +1,120 @@
+# IOPMP Reference Model Documentation
+
+The **Input/Output Physical Memory Protection (IOPMP)** is a hardware component designed to control and validate accesses issued from bus initiators. It checks the validity of these accesses in real-time. The **IOPMP Reference Model** is developed in compliance with the **RISC-V IOPMP Specification Version 0.9.2-RC2 (November 2024)**. This model is currently in the development phase and will be updated with future specification revisions.
+
+## IOPMP Model Overview
+
+The IOPMP Reference Model includes several distinct configurations, each offering different levels of functionality and flexibility in controlling physical memory protection. The following table provides an overview of the available models:
+
+| **Model Name** | **SRCMD_FMT** | **MDCFG_FMT** | **Description** |
+|----------------|---------------|---------------|-----------------|
+| **Full Model** | 0             | 0             | **Max Supported RRIDs:** 65536<br> **Max Supported MDs:** 63<br> Uses the RRID to obtain `SRCMD_EN(H)`, which indicates the associated MDs.<br> The `MDCFG` table is traversed to retrieve the associated MDs.<br> Associated IOPMP entries are extracted from the respective MD and traversed for address matching and permission checks. |
+| **Rapid-k Model** | 0          | 1             | **Max Supported RRIDs:** 65536<br> **Max Supported MDs:** 63<br> Uses the RRID to obtain `SRCMD_EN(H)`, indicating the associated MDs.<br> There is no physical `MDCFG` table in this model. Each MD has *k* associated IOPMP entries.<br> IOPMP entries linked to the MD associated with the RRID are traversed for address matching and permission checks.<br> **IOPMP Entry Ranges for Each MD:**<br>  `MD0 → 0 to (k - 1)`<br>  `MD1 → k to (2k - 1)`<br>  `MD2 → 2k to (3k - 1)`, and so on. |
+| **Dynamic-k Model** | 0        | 2             | Same as the **Rapid-k Model**, but the value of *k* is programmable. |
+| **Isolation Model** | 1        | 0             | **Max Supported RRIDs:** 63<br> **Max Supported MDs:** 63<br> There is no physical `SRCMD` table. Instead, `RRID i` directly maps to `MD i`.<br> Associated IOPMP entries are extracted from `MD i` and traversed for address matching and permission checks. |
+| **Compact-k Model** | 1        | 1             | **Max Supported RRIDs:** 63<br> **Max Supported MDs:** 63<br> There is no physical `SRCMD` table. `RRID i` directly maps to `MD i`.<br> There is no physical `MDCFG` table. Each MD has *k* associated IOPMP entries.<br> **Associated IOPMP Entry Ranges:**<br>  `(i × k)` to `((i + 1) × k - 1)` for address matching and permission checks. |
+| **Unnamed Model 1** | 1 | 2           | Same as the **Compact-k Model**, but the value of *k* is programmable. |
+| **Unnamed Model 2** | 2                   | 0             | **Max Supported RRIDs:** 32<br> **Max Supported MDs:** 63<br> `SRCMD_EN(H)` and `SPS` extension registers are replaced with `SRCMD_PERM(H)`.<br> All MDs are associated with the given RRID.<br> The `MDCFG` table is traversed for all MDs.<br> Associated IOPMP entries are extracted and traversed for address matching and permission checks. |
+| **Unnamed Model 3** | 2                   | 1             | **Max Supported RRIDs:** 32<br> **Max Supported MDs:** 63<br> `SRCMD_EN(H)` and `SPS` extension registers are replaced with `SRCMD_PERM(H)`.<br> There is no physical `MDCFG` table. Each MD has *k* associated IOPMP entries.<br> `SRCMD_PERM(H)` only defines permissions, not associated MDs. All IOPMP entries are traversed for address matching and permission checks. |
+| **Unnamed Model 4** | 2                   | 2             | Same as **Unnamed Model 3**, but the value of *k* is programmable. |
+
+## Supported Features
+
+The **IOPMP Reference Model** incorporates all features as outlined in the **RISC-V IOPMP Specification Version 0.9.2-RC2 (November 2024)**. Key features include:
+
+| **Feature**  | **Possible Values** | **Description**                                                                                                                                                                                                                    |
+| ------------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TOR_EN             | 0/1                       | Indicates if Top-Of-Range (TOR) addressing mode is supported.<br />**0**: TOR not supported. <br />**1**: TOR supported                                                                                                      |
+| SPS_EN             | 0/1                       | Indicates if Secondary Permission Settings (SPS) are supported.<br />**0**: SPS not supported. <br />**1**: SPS is supported                                                                                                    |
+| PRIENT_PROG        | 0/1                       | Indicates if the `prio_entry` field in HWCFG2 is programmable.<br /> **0**: Field is fixed. <br />**1**: Field is programmable                                                                                             |
+| RRID_TRANSL_EN     | 0/1                       | Indicates if tagging a new Requestor ID (RRID) on the initiator port is supported.<br />**0**: Tagging not supported. <br />**1**: New RRID tagging is supported.                                                            |
+| RRID_TRANSL_PROG   | 0/1                       | Indicates if the `rrid_transl` field is programmable. <br />**0**: Field is fixed. <br />**1**: Field is programmable                                                                                                      |
+| CHK_X              | 0/1                       | Indicates if the IOPMP implements check of an instruction fetches based on the instruction fetches fields<br />**0**: Fields of instruction fetches are ignored<br />**1**: Fields of instruction fetches are not ignored |
+| NO_X               | 0/1                       | Valid only if `CHK_X` = 1. <br />**0**: Instruction fetch checks are permissive. <br />**1**: Instruction fetches are always denied.                                                                                       |
+| NO_W               | 0/1                       | Indicates if write accesses are always denied.<br />**0**: Write accesses are allowed based on permissions. <br />**1**: Write accesses are always denied.                                                                   |
+| STALL_EN           | 0/1                       | Indicates if stalling is supported.<br />**0**: No stalling supported. <br />**1**: Stalling features are implemented.                                                                                                       |
+| PEIS               | 0/1                       | Indicates if Per-Entry Interrupt Suppression is supported.<br />**0**: Feature not supported. <br />**1**: Interrupts can be suppressed per entry.                                                                           |
+| PEES               | 0/1                       | Indicates if Per-Entry Error Suppression is supported.<br />**0**: Feature not supported. <br />**1**: Errors can be suppressed per entry.                                                                                   |
+| MFR_EN             | 0/1                       | Indicates if Multi Fault Record Extension is supported.<br />**0**: Feature not supported. <br />**1**: Subsequent violations will be recorded.                                                                              |
+| MD_ENTRY_NUM       | 0 - IMP                   | Indicates the number of entries associated with each Memory Domain (MD) when `MDCFG_FMT` is not 0.<br />Implementation defined value                                                                                                   |
+| MD_NUM             | 0 - 63                    | Indicates the maximum number of supported Memory Domain (MD).                                                                                                                                                                            |
+| ADDRH_EN           | 0/1                       | Indicates if higher-address fields are available.<br />**0**: Higher-address fields not available. <br />**1**: Higher-address fields are implemented.                                                                       |
+| RRID_NUM           | 0 - 65535                 | Indicates the maximum number of Requestor IDs (RRIDs) supported.                                                                                                                                                                         |
+| ENTRY_NUM          | 0 - IMP                   | Indicates the total number of entries supported.                                                                                                                                                                                         |
+| PRIO_ENTRY         | 1 - ENTRY_NUM             | Indicates the number of entries matched based on priority.                                                                                                                                                                               |
+| ERROR_CAPTURE_EN   | 0/1                       | Indicates if the Error Capture Record feature is implemented.<br />**0**: Feature not supported. <br />**1**: Error details can be captured and logged.                                                                      |
+| IMP_ERROR_REQID    | 0/1                       | Indicates if `ERR_REQID` is implemented. <br />**0**: Feature not supported. <br />**1**: Errored RRID and Entry num is recorded.                                                                                          |
+| IMP_MDLCK          | 0/1                       | Indicates if the Memory Domain Lock (MDLCK) feature is implemented.<br />**0**: Feature is not implemented<br />**1**: Memory domains can be locked.                                                                         |
+| REG_INTF_BUS_WIDTH | 4/8                       | Specifies the width (in bytes) of the register interface bus.<br />**4**: 4-byte width. <br />**8**: 8-byte width.                                                                                                           |
+| MSI_EN             | 0/1                       | Indicates if Messaged-Signal-Interrupts are supported.<br />**0:** MSI is not supported.<br />**1:** MSI can be generated.                                                                                                |
+
+## Reference Model Functions
+
+These functions are designed for use within a testbench to input stimuli and obtain responses from the respective models:
+
+1. **`int reset_iopmp()`**  
+   Resets the IOPMP registers to their default values. The function returns 0 if the reference model is successfully initialized.
+
+2. **`void write_register(uint16_t offset, reg_intf_dw data, uint8_t num_bytes)`**  
+   Writes data to a memory-mapped register identified by the specified offset. The number of bytes written is specified by `num_bytes`. If the access is invalid, the write is ignored. The data type `reg_intf_dw` depends on the configuration in the `config.h` file (e.g., `uint32_t` for 4-byte width, `uint64_t` for 8-byte width).
+
+3. **`reg_intf_dw read_register(uint16_t offset, uint8_t num_bytes)`**  
+   Reads data from a memory-mapped register identified by the specified offset. The number of bytes to read is specified by `num_bytes`. If the access is invalid, the function returns zeros. The data type `reg_intf_dw` is dependent on the bus width defined in `config.h`.
+   
+4. **`int create_memory(uint8_t mem_gb)`**  
+   Allocates memory of the specified size in gigabytes. mem_gb is used for the size of the memory to allocate in gigabytes. It returns 0 if the memory allocation was successful, -1 otherwise.
+
+5. **`uint8_t read_memory(uint64_t addr, uint8_t size, char *data)`**  
+   Read data from a specific memory address. The param addr is the memory address from where the data should be read. The param size is the size of the data in bytes. The pram data is the pointer to the data for read. It returns 0 if the read was successful, BUS_ERROR if the address corresponds to a bus error.
+
+6. **`uint8_t write_memory(char *data, uint64_t addr, uint32_t size)`**  
+   This function writes data to a specific memory address, the param data indicates Pointer to the data to write, the param addr is the memory address where the data should be written and param size will be the size of the data in bytes. it returns 0 if the write was successful, BUS_ERROR if the address corresponds to a bus error.
+
+7. **`void configure_srcmd_n(uint8_t srcmd_reg, uint16_t srcmd_idx, reg_intf_dw data, uint8_t num_bytes)`**  
+   This function is used for SRCMD Table Configurations. The param srcmd_reg could be SRCMD_EN, SRCMD_ENH, SRCMD_R, SRCMD_RH, SRCMD_W, SRCMD_WH. srcmd_idx could be any legal SRCMD table index, data contains the value that you want to write in this register. The number of bytes to write is specified by `num_bytes`. It could be 4-Byte write or 8-Byte Write.
+
+8. **`void configure_mdcfg_n(uint8_t md_idx, reg_intf_dw data, uint8_t num_bytes)`**  
+   This function is used for MDCFG Table Configurations. md_idx could be any legal MDCFG table index, data contains the value that you want to write in this register. The number of bytes to write is specified by `num_bytes`. It could be 4-Byte write or 8-Byte Write.
+
+9. **`void configure_entry_n(uint8_t entry_reg, uint64_t entry_idx, reg_intf_dw data, uint8_t num_bytes)`**  
+   This function is used for Entry Table Configurations. entry_idx could be any legal Entry table index, data contains the value that you want to write in this register. The number of bytes to write is specified by `num_bytes`. It could be 4-Byte write or 8-Byte Write.
+
+10. **`void receiver_port(uint16_t rrid, uint64_t addr, uint32_t length, uint32_t size, perm_type_e perm, iopmp_trans_req_t *iopmp_trans_req)`**  
+   This function contains receiver port signals, that will be passed to the iopmp, where rrid is RRID Of the Bus Initiator, addr is Address to be checked, length is length Number of transfers, size is It should be 0 for 1-byte, 1 for 2-byte, 2 for 4-byte access, perm is the permissions required for this transcation, iopmp_trans_req is a pointer, pass it as it is.
+
+11. **`int error_record_chk(uint8_t err_type, uint8_t req_perm, uint64_t req_addr, bool err_rcd)`**  
+   This could be used to check the error record register data. err_type is the ype of Error, req_perm contains the Requested permissions, req_addr contains the requested address, err_rcd indicated if Set if error should be recorded
+
+## **Compilation and Simulation of IOPMP Models**
+
+The **IOPMP Reference Model** is written in C and requires a GCC compiler for compilation. Follow these steps to compile and simulate:
+
+1. Adjust the `config.h` file as needed to customize IOPMP configurations.
+2. Use the following commands to compile:
+
+   - **Compile All Models**:  
+     ```bash
+     make all
+     ```
+   - **Compile Specific Models**:  
+     ```bash
+     make build model=full_model        # Full Model  
+     make build model=rapid_k_model     # Rapid-k Model  
+     make build model=dynamic_k_model   # Dynamic-k Model  
+     make build model=isolation_model   # Isolation Model  
+     make build model=compact_k_model   # Compact-k Model  
+     make build model=unnamed_model_1   # Unnamed Model 1  
+     make build model=unnamed_model_2   # Unnamed Model 2  
+     make build model=unnamed_model_3   # Unnamed Model 3  
+     make build model=unnamed_model_4   # Unnamed Model 4
+     ```
+
+3. After compilation, binaries are generated in the `bin` folder and the library files are generated in `lib` folder.
+
+## IOPMP Reference Model Test Files
+
+The `verif` directory contains a `test` folder that includes test files for each of the 9 models. You can add custom tests to the relevant test file for your preferred model.
+
+---
+
+This document serves as a comprehensive guide to the **IOPMP Reference Model** for Input/Output Physical Memory Protection, offering both detailed specifications and practical instructions for use in simulation and verification tasks.

--- a/iopmp_ref_model/include/config.h
+++ b/iopmp_ref_model/include/config.h
@@ -1,5 +1,6 @@
 /***************************************************************************
 // Author: Yazan Hussnain (yazan.hussain@10xengineers.ai)
+//         Gull Ahmed (gull.ahmed@10xengineers.ai)
 // Date: October 21, 2024
 // Description: This file contains all the configuration parameters
 // that a user could change before compilation.
@@ -18,26 +19,30 @@
 #define IOPMP_PEES              1
 #define IOPMP_MFR_EN            1
 #define IOPMP_MD_ENTRY_NUM      3
-#define IOPMP_MD_NUM            63      // Max 63 MD is supported
+#define IOPMP_MD_NUM            63          // Max 63 MD is supported
 #define IOPMP_ADDRH_EN          1
 #define IOPMP_ENABLE            0
 #define IOPMP_ENTRY_NUM         512
 #define IOPMP_PRIO_ENTRY        16
 #define IOPMP_RRID_TRANSL       48
-#define USER                    0x80      // It could be any user defined value, incase of error suppression
-#define ERROR_CAPTURE_EN        1
-#define IMP_ERROR_REQID         1
-#define IMP_MDLCK               1
-#define MSI_EN                  1
 
-#define ENTRY_OFFSET            0x8000
+#define USER                    0x80        // User-defined value for error suppression success responses.
+#define ERROR_CAPTURE_EN        1           // Indicates if the Error Capture Record feature is implemented.
+#define IMP_ERROR_REQID         1           // Indicates if the ERR_REQID register is implemented.
+#define IMP_MDLCK               1           // Indicates if the Memory Domain Lock (MDLCK) feature is implemented.
+#define MSI_EN                  1           // Indicates if Message-Signal Interrupts are supported.
+#define STALL_BUF_DEPTH         32          // Depth of the stall transaction buffer.
+#define SRC_ENFORCEMENT_EN      0           // Indicates if source enforcement is enabled.
+#define IMP_RRIDSCP             1           // Indicates if the RRIDSCP register is implemented.
 
-#define REG_INTF_BUS_WIDTH      4
+#define ENTRY_OFFSET            0x2000      // Offset for the entry table.
+
+#define REG_INTF_BUS_WIDTH      4           // Width (in bytes) of the register interface bus.
 
 #if (SRCMD_FMT == 0)
     #define IOPMP_RRID_NUM      64
 #elif (SRCMD_FMT == 1)
-    #define IOPMP_RRID_NUM      63      // Max RRID Num could be 63 when SRCMD_FMT is 1, because RRID is directly mapped to MD's
+    #define IOPMP_RRID_NUM      63          // Maximum RRID number when SRCMD_FMT is 1, as RRID is directly mapped to MDs.
 #else
-    #define IOPMP_RRID_NUM      32      // Max RRID Num could be 32 when SRCMD_FMT is 2, because SRCMD_PERM is 32 bits
+    #define IOPMP_RRID_NUM      32          // Maximum RRID number when SRCMD_FMT is 2, as SRCMD_PERM is 32 bits.
 #endif

--- a/iopmp_ref_model/include/config.h
+++ b/iopmp_ref_model/include/config.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+// Author: Yazan Hussnain (yazan.hussain@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the configuration parameters
+// that a user could change before compilation.
+***************************************************************************/
+
+#define IOPMP_TOR_EN            1
+#define IOPMP_SPS_EN            1
+#define IOPMP_PARIENT_PROG      0
+#define IOPMP_RRID_TRANSL_EN    1
+#define IOPMP_RRID_TRANSL_PROG  0
+#define IOPMP_CHK_X             1
+#define IOPMP_NO_X              0
+#define IOPMP_NO_W              0
+#define IOPMP_STALL_EN          1
+#define IOPMP_PEIS              1
+#define IOPMP_PEES              1
+#define IOPMP_MFR_EN            1
+#define IOPMP_MD_ENTRY_NUM      3
+#define IOPMP_MD_NUM            63      // Max 63 MD is supported
+#define IOPMP_ADDRH_EN          1
+#define IOPMP_ENABLE            0
+#define IOPMP_ENTRY_NUM         512
+#define IOPMP_PRIO_ENTRY        16
+#define IOPMP_RRID_TRANSL       48
+#define USER                    0x80      // It could be any user defined value, incase of error suppression
+#define ERROR_CAPTURE_EN        1
+#define IMP_ERROR_REQID         1
+#define IMP_MDLCK               1
+#define MSI_EN                  1
+
+#define ENTRY_OFFSET            0x8000
+
+#define REG_INTF_BUS_WIDTH      4
+
+#if (SRCMD_FMT == 0)
+    #define IOPMP_RRID_NUM      64
+#elif (SRCMD_FMT == 1)
+    #define IOPMP_RRID_NUM      63      // Max RRID Num could be 63 when SRCMD_FMT is 1, because RRID is directly mapped to MD's
+#else
+    #define IOPMP_RRID_NUM      32      // Max RRID Num could be 32 when SRCMD_FMT is 2, because SRCMD_PERM is 32 bits
+#endif

--- a/iopmp_ref_model/include/iopmp.h
+++ b/iopmp_ref_model/include/iopmp.h
@@ -30,9 +30,8 @@
 #define IOPMP_NA4   2  // Naturally aligned 4-byte regions
 #define IOPMP_NAPOT 3  // Naturally aligned power of two regions
 
-#define BUS_ERROR     0x3
+#define BUS_ERROR     0xC
 #define MSI_DATA_BYTE 0x4
-#define MAX_SVS       0xFFFF
 
 #define WORD_BITS        32
 #define SRCMD_REG_STRIDE 32
@@ -52,23 +51,26 @@
 #define MASK_BIT_POS(BIT_POS) ((1U << BIT_POS) - 1)
 #define GET_BIT(VAL, BIT_NUM) ((VAL >> BIT_NUM) & 1)
 
+
 // Global Variables: Definitions for IOPMP global variables
 extern iopmp_regs_t g_reg_file;        // Global register file for IOPMP
 extern iopmp_entries_t iopmp_entries;  // IOPMP entry table
 extern err_mfrs_t err_svs;             // Error status vector
 extern int intrpt_suppress;            // Set when interrupt is suppressed
 extern int error_suppress;             // Set when error is suppressed
-extern int rrid_stall[IOPMP_RRID_NUM];      // Stall status array for requester IDs
+extern int rrid_stall[IOPMP_RRID_NUM]; // Stall status array for requester IDs
+extern int stall_cntr;                 // Counts stalled transactions
 
-extern uint8_t write_memory(char *data, uint64_t addr, uint32_t size);
-extern uint8_t read_memory(uint64_t addr, uint8_t size, char *data);
+extern uint8_t write_memory(uint64_t *data, uint64_t addr, uint32_t size);
 
 // Function Declarations: Core IOPMP operations
 int iopmpAddrRange(uint64_t *startAddr, uint64_t *endAddr, uint64_t prev_iopmpaddr, uint64_t iopmpaddr, entry_cfg_t iopmpcfg);
 int iopmpMatchAddr(iopmp_trans_req_t trans_req, uint64_t lo, uint64_t hi, int is_priority);
 iopmpMatchStatus_t iopmpCheckPerms(uint16_t rrid, perm_type_e req_perm, entry_cfg_t iopmpcfg, uint8_t md);
 iopmpMatchStatus_t iopmpRuleAnalyzer(iopmp_trans_req_t trans_req, uint64_t prev_iopmpaddr, uint64_t iopmpaddr, entry_cfg_t iopmpcfg, uint8_t md, int is_priority);
-iopmp_trans_rsp_t iopmp_validate_access(iopmp_trans_req_t trans_req, uint8_t *intrpt);
+extern void iopmp_validate_access(iopmp_trans_req_t *trans_req, iopmp_trans_rsp_t* iopmp_trans_rsp, uint8_t *intrpt);
+void setRridSv(uint16_t rrid);
+int checkRridSv(uint16_t rrid);
 void errorCapture(perm_type_e trans_type, uint8_t error_type, uint16_t rrid, uint16_t entry_id, uint64_t err_addr, uint8_t *intrpt);
 void generate_interrupt(uint8_t *intrpt);
 

--- a/iopmp_ref_model/include/iopmp.h
+++ b/iopmp_ref_model/include/iopmp.h
@@ -1,0 +1,75 @@
+/***************************************************************************
+// Authors: Mazhar Ali (mazhar.ali@10xengineers.ai)
+//          Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: IOPMP Header File
+// This header file defines structures, macros, and function prototypes
+// for the Input/Output Physical Memory Protection (IOPMP). It includes
+// the primary modes of operation for the IOPMP (off, TOR, NA4, NAPOT) and
+// provides declarations for the primary functions used to process access
+// requests, match addresses, check permissions, analyze rules, and handle
+// error capture. Additionally, macros for testing and transaction checks
+// are defined to support validation and debugging.
+***************************************************************************/
+
+#ifndef IOPMP_H
+#define IOPMP_H
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>
+#include "iopmp_registers.h"
+#include "iopmp_req_rsp.h"
+
+// IOPMP Mode Types: Define operational modes for IOPMP
+#define IOPMP_OFF   0  // IOPMP is disabled
+#define IOPMP_TOR   1  // Top-of-Range mode
+#define IOPMP_NA4   2  // Naturally aligned 4-byte regions
+#define IOPMP_NAPOT 3  // Naturally aligned power of two regions
+
+#define BUS_ERROR     0x3
+#define MSI_DATA_BYTE 0x4
+#define MAX_SVS       0xFFFF
+
+#define WORD_BITS        32
+#define SRCMD_REG_STRIDE 32
+#define ENTRY_REG_STRIDE 16
+#define MIN_REG_WIDTH    4
+
+// Helper Macros for Register Calculations
+#define SRCMD_TABLE_INDEX(offset) (((offset) - SRCMD_TABLE_BASE_OFFSET) / SRCMD_REG_STRIDE)
+#define ENTRY_TABLE_INDEX(offset) (((offset) - ENTRY_TABLE_BASE_OFFSET) / ENTRY_REG_STRIDE)
+#define SRCMD_REG_INDEX(offset)   ((((offset) - SRCMD_TABLE_BASE_OFFSET) % SRCMD_REG_STRIDE) / MIN_REG_WIDTH)
+#define ENTRY_REG_INDEX(offset)   ((((offset) - ENTRY_TABLE_BASE_OFFSET) % ENTRY_REG_STRIDE) / MIN_REG_WIDTH)
+#define IS_IN_RANGE(offset, start, end) (((offset) >= (start)) && ((offset) <= (end)))
+#define CONCAT32(upr_bits, lwr_bits) (((uint64_t)upr_bits << WORD_BITS) | lwr_bits)
+#define IS_MD_ASSOCIATED(md_num, srcmd_en_md, srcmd_enh_mdh) \
+    ((md_num < 31) ? ((srcmd_en_md >> md_num) & 1) : ((srcmd_enh_mdh >> (md_num - 31)) & 1))
+
+#define MASK_BIT_POS(BIT_POS) ((1U << BIT_POS) - 1)
+#define GET_BIT(VAL, BIT_NUM) ((VAL >> BIT_NUM) & 1)
+
+// Global Variables: Definitions for IOPMP global variables
+extern iopmp_regs_t g_reg_file;        // Global register file for IOPMP
+extern iopmp_entries_t iopmp_entries;  // IOPMP entry table
+extern err_mfrs_t err_svs;             // Error status vector
+extern int intrpt_suppress;            // Set when interrupt is suppressed
+extern int error_suppress;             // Set when error is suppressed
+extern int rrid_stall[IOPMP_RRID_NUM];      // Stall status array for requester IDs
+
+extern uint8_t write_memory(char *data, uint64_t addr, uint32_t size);
+extern uint8_t read_memory(uint64_t addr, uint8_t size, char *data);
+
+// Function Declarations: Core IOPMP operations
+int iopmpAddrRange(uint64_t *startAddr, uint64_t *endAddr, uint64_t prev_iopmpaddr, uint64_t iopmpaddr, entry_cfg_t iopmpcfg);
+int iopmpMatchAddr(iopmp_trans_req_t trans_req, uint64_t lo, uint64_t hi, int is_priority);
+iopmpMatchStatus_t iopmpCheckPerms(uint16_t rrid, perm_type_e req_perm, entry_cfg_t iopmpcfg, uint8_t md);
+iopmpMatchStatus_t iopmpRuleAnalyzer(iopmp_trans_req_t trans_req, uint64_t prev_iopmpaddr, uint64_t iopmpaddr, entry_cfg_t iopmpcfg, uint8_t md, int is_priority);
+iopmp_trans_rsp_t iopmp_validate_access(iopmp_trans_req_t trans_req, uint8_t *intrpt);
+void errorCapture(perm_type_e trans_type, uint8_t error_type, uint16_t rrid, uint16_t entry_id, uint64_t err_addr, uint8_t *intrpt);
+void generate_interrupt(uint8_t *intrpt);
+
+#endif // IOPMP_H

--- a/iopmp_ref_model/include/iopmp_registers.h
+++ b/iopmp_ref_model/include/iopmp_registers.h
@@ -32,7 +32,7 @@
 #define MDCFGLCK_OFFSET       0x48
 #define ENTRYLCK_OFFSET       0x4C
 #define ERR_OFFSET            0x60
-#define ERR_REQINFO_OFFSET    0x64
+#define ERR_INFO_OFFSET       0x64
 #define ERR_REQADDR_OFFSET    0x68
 #define ERR_REQADDRH_OFFSET   0x6C
 #define ERR_REQID_OFFSET      0x70
@@ -59,9 +59,9 @@
     typedef uint64_t reg_intf_dw;
 #endif
 
-int reset_iopmp(void);
-reg_intf_dw read_register(uint16_t offset, uint8_t num_bytes);
-void write_register(uint16_t offset, reg_intf_dw data, uint8_t num_bytes);
+extern int reset_iopmp(void);
+extern reg_intf_dw read_register(uint64_t offset, uint8_t num_bytes);
+extern void write_register(uint64_t offset, reg_intf_dw data, uint8_t num_bytes);
 void rrid_stall_update(uint8_t exempt);
 
 // VERSION register is a read-only register reporting
@@ -203,7 +203,7 @@ typedef union {
         uint32_t md     : 31;                   // Writting md[i]=1 selects MD i; reading md[i] = 1 means MD i selected.
     };
     struct {
-        uint32_t is_stalled : 1;                // After the last writing of MDSTALL (included) plus any following writing RRIDSCP, 1
+        uint32_t is_busy : 1;                   // After the last writing of MDSTALL (included) plus any following writing RRIDSCP, 1
                                                 // indicates that all requested stalls take effect; otherwise, 0. After the last writing
                                                 // MDSTALLH (if any) and then MDSTALL by zero, 0 indicates that all transactions have
                                                 // been resumed; otherwise, 1.
@@ -305,7 +305,8 @@ typedef union {
                                            // • 0x0: respond an implementation-dependent error, such as a bus error
                                            // • 0x1: respond a success with a pre-defined value to the requestor instead of an error
         uint32_t msi_en  : 1;              // It indicates whether the IOPMP triggers MSI
-        uint32_t rsv1    : 4;              // reserved for future use
+        uint32_t stall_violation_en  : 1;  // It indicates whether the IOPMP faults stalled transactions
+        uint32_t rsv1    : 3;              // reserved for future use
         uint32_t msidata : 11;             // The data to trigger MSI
 
         uint32_t rsv2    : 13;             // reserved for future use
@@ -313,7 +314,7 @@ typedef union {
     uint32_t raw;
 } err_cfg_t;
 
-// ERR_REQINFO captures more detailed error infomation.
+// ERR_INFO captures more detailed error information.
 typedef union {
     struct {
         uint32_t v     : 1;                 // Indicate if the illegal capture recorder register has a
@@ -325,7 +326,7 @@ typedef union {
                                             // 0x02 = write access
                                             // 0x03 = instruction fetch
 
-        uint32_t rsv1  : 1;                 // reserved for future use
+        uint32_t msi_werr  : 1;             // It’s asserted when IOPMP-originated MSI has failed.
 
         uint32_t etype : 3;                 // Indicates the type of violation
                                             // 0x00 = no error
@@ -340,10 +341,10 @@ typedef union {
         uint32_t svc   : 1;                 // Indicate there is a subsequent violation caught in ERR_MFR.
                                             // Implemented only for HWCFG0.mfr_en=1,
 
-        uint32_t rsv2  : 24;                // reserved for future use
+        uint32_t rsv   : 24;                // reserved for future use
     };
     uint32_t raw;
-} err_reqinfo_t;
+} err_info_t;
 
 // ERR_REQADDR indicate the errored request address.
 typedef union {
@@ -639,7 +640,11 @@ typedef union {
         #if (IOPMP_STALL_EN)
         mdstall_t        mdstall;
         mdstallh_t       mdstallh;
+        #if (IMP_RRIDSCP)
         rridscp_t        rridscp;
+        #else
+        uint32_t         reserved10;
+        #endif
         #else
         uint32_t         reserved7[3];
         #endif
@@ -658,7 +663,7 @@ typedef union {
         entrylck_t       entrylck;
         uint32_t         reserved2[4];
         err_cfg_t        err_cfg;
-        err_reqinfo_t    err_reqinfo;
+        err_info_t       err_info;
         err_reqaddr_t    err_reqaddr;
         err_reqaddrh_t   err_reqaddrh;
         err_reqid_t      err_reqid;
@@ -696,7 +701,7 @@ typedef union {
 } iopmp_entries_t;
 
 typedef struct {
-    err_mfr_t sv[IOPMP_RRID_NUM];
+    err_mfr_t sv[IOPMP_RRID_NUM/16];
 } err_mfrs_t;
 
 #endif

--- a/iopmp_ref_model/include/iopmp_registers.h
+++ b/iopmp_ref_model/include/iopmp_registers.h
@@ -1,0 +1,702 @@
+/***************************************************************************
+// Authors: Mazhar Ali (mazhar.ali@10xengineers.ai)
+//          Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This header file provides a comprehensive definition of
+// the IOPMP MMAP registers, designed to support flexibility and modularity
+// in various IOPMP configurations. It defines all necessary registers while
+// allowing customization by including or excluding specific register
+// definitions based on the IOPMP model being implemented. Additionally,
+// it separates the entry table definition from the remaining structure
+// in which the rest of the registers are defined, as the entry offset
+// is implementation-dependent.
+***************************************************************************/
+
+#include "config.h"
+
+#ifndef IOPMP_REGS
+#define IOPMP_REGS
+
+// Offset to fields
+#define VERSION_OFFSET        0x00
+#define IMPLEMENTATION_OFFSET 0x04
+#define HWCFG0_OFFSET         0x08
+#define HWCFG1_OFFSET         0x0C
+#define HWCFG2_OFFSET         0x10
+#define ENTRYOFFSET_OFFSET    0x14
+#define MDSTALL_OFFSET        0x30
+#define MDSTALLH_OFFSET       0x34
+#define RRISCP_OFFSET         0x38
+#define MDLCK_OFFSET          0x40
+#define MDLCKH_OFFSET         0x44
+#define MDCFGLCK_OFFSET       0x48
+#define ENTRYLCK_OFFSET       0x4C
+#define ERR_OFFSET            0x60
+#define ERR_REQINFO_OFFSET    0x64
+#define ERR_REQADDR_OFFSET    0x68
+#define ERR_REQADDRH_OFFSET   0x6C
+#define ERR_REQID_OFFSET      0x70
+#define ERR_MFR_OFFSET        0x74
+#define ERR_MSIADDR_OFFSET    0x78
+#define ERR_MSIADDRH_OFFSET   0x7C
+
+#define ERR_USER0_OFFSET      0x80
+#define ERR_USER1_OFFSET      0x84
+#define ERR_USER2_OFFSET      0x88
+#define ERR_USER3_OFFSET      0x8C
+#define ERR_USER4_OFFSET      0x90
+#define ERR_USER5_OFFSET      0x94
+#define ERR_USER6_OFFSET      0x98
+#define ERR_USER7_OFFSET      0x9C
+
+#define MDCFG_TABLE_BASE_OFFSET 0x0800
+#define SRCMD_TABLE_BASE_OFFSET 0x1000
+#define ENTRY_TABLE_BASE_OFFSET ENTRY_OFFSET
+
+#if (REG_INTF_BUS_WIDTH == 4)
+    typedef uint32_t reg_intf_dw;
+#elif (REG_INTF_BUS_WIDTH == 8)
+    typedef uint64_t reg_intf_dw;
+#endif
+
+int reset_iopmp(void);
+reg_intf_dw read_register(uint16_t offset, uint8_t num_bytes);
+void write_register(uint16_t offset, reg_intf_dw data, uint8_t num_bytes);
+void rrid_stall_update(uint8_t exempt);
+
+// VERSION register is a read-only register reporting
+// IOPMP comfiguration information of the instance:
+// 1. vendor ID
+// 2. Specification Version
+typedef union {
+
+    struct {
+        uint32_t vendor  : 24;              // The vendor ID
+        uint32_t specver : 8;               // The specification version
+    };
+    uint32_t raw;
+} version_t;
+
+// IMPLEMENTATION register is a read-only register reporting
+// implementation ID specific to the instance
+typedef union {
+    struct {
+        uint32_t impid;                     // The user-defined implementation ID.
+    };
+    uint32_t raw;
+} implementation_t;
+
+// HWCFG0 register is one of hrdware configuration registers reporting
+// features supported by IOPMP. each bit if bot clear indicates
+// presence of that feature in IOPMP
+typedef union {
+    struct {
+        uint32_t mdcfg_fmt          : 2;    // Indicate the MDCFG format
+                                            //  -> 0x0: Format 0. MDCFG table is implemented.
+                                            //  -> 0x1: Format 1. No MDCFG table. HWCFG.md_entry_num is fixed.
+                                            //  -> 0x2: Format 2. No MDCFG table. HWCFG.md_entry_num is programmable.
+                                            //  -> 0x3: reserved.
+
+        uint32_t srcmd_fmt          : 2;    // Indicate the MDCFG format
+                                            //  -> 0x0: Format 0. SRCMD_EN(s) and SRCMD_ENH(s) are available.
+                                            //  -> 0x1: Format 1. No SRCMD table.
+                                            //  -> 0x2: Format 2. SRCMD_PERM(m) and SRCMD_PERMH(m) are available.
+                                            //  -> 0x3: reserved.
+
+        uint32_t tor_en             : 1;    // Indicate if TOR is supported
+
+        uint32_t sps_en             : 1;    // Indicate secondary permission settings is supported; which are SRCMD_R/RH(i)
+                                            // and SRCMD_W/WH registers
+
+        uint32_t user_cfg_en        : 1;    // Indicate if user customized attributes is supported; which are
+                                            // ENTRY_USER_CFG(i) registers.
+
+        uint32_t prient_prog        : 1;    // A write-1-clear bit is sticky to 0 and indicates if HWCFG2.prio_entry
+                                            // is programmable. Reset to 1 if the implementation supports programmable
+                                            // prio_entry, otherwise, wired to 0.
+
+        uint32_t rrid_transl_en     : 1;    // Indicate the if tagging a new RRID on the requestor port is supported
+
+        uint32_t rrid_transl_prog   : 1;    // A write-1-set bit is sticky to 0 and indicate if the field sid_transl
+                                            // is programmable. Support only for rrid_transl_en=1, otherwise, wired to 0.
+
+        uint32_t chk_x              : 1;    // Indicate if the IOPMP implements the check of an
+                                            // instruction fetch. On chk_x=0, all fields of illegal
+                                            // instruction fetches are ignored, including
+                                            // HWCFG0.no_x, ENTRY_CFG(i).sixe, ENTRY_CFG(
+                                            // i).esxe, and ENTRY_CFG(i).x. It should be wired to
+                                            // zero if there is no indication for an instruction fetch
+                                            // otherwise, it should depend on x-bit in ENTRY_CFG(i).
+
+        uint32_t no_x               : 1;    // For chk_x=1, the IOPMP with no_x=1 always fails on
+                                            // an instruction fetch; otherwise, it should depend on
+                                            // x-bit in ENTRY_CFG(i). For chk_x=0, no_x has no
+                                            // effect
+
+        uint32_t no_w               : 1;    // Indicate if the IOPMP always fails write accesses
+
+        uint32_t stall_en           : 1;    // Indicate if the IOPMP implements stall-related features, which are MDSTALL,
+                                            // MDSTALLH, and RRIDSCP registers.
+
+        uint32_t peis               : 1;    // Indicate if the IOPMP implements interrupt suppression per entry
+
+        uint32_t pees               : 1;    // Indicate if the IOPMP implements the error suppression per entry
+
+        uint32_t mfr_en             : 1;    // Indicate if the IOPMP implements Multi Faults Record Extension
+
+        uint32_t md_entry_num       : 7;    // When HWCFG0.mdcfg_fmt =
+                                            //  -> 0x0: must be zero
+                                            //  -> 0x1 or 0x2: md_entry_num indicates each memory domain exactly has
+                                            //    (md_entry_num + 1) entries in a memory domain
+                                            // md_entry_num is locked if HWCFG0.enable is 1.
+
+        uint32_t md_num             : 6;    // Indicate the supported number of MD in the instance
+
+        uint32_t addrh_en           : 1;    // Indicate if the IOPMP implements ENTRY_ADDRH(i)
+
+        uint32_t enable             : 1;    // Indicate if the IOPMP checks transactions by default.
+                                            // If it is implemented, it should be initial to 0 and sticky to 1.
+                                            // If it is not implemented, it should be wired to 1.
+    };
+    uint32_t raw;
+} hwcfg0_t;
+
+// HWCFG1 register is one of hrdware configuration
+// registers reporting features supported by IOPMP.
+typedef union {
+    struct {
+        uint32_t rrid_num  : 16;            // Indicate the supported number of RRID in the instance
+        uint32_t entry_num : 16;            // Indicate the supported number of entries in the instance
+    };
+    uint32_t raw;
+} hwcfg1_t;
+
+// HWCFG2 register is one of hrdware configuration
+// registers reporting features supported by IOPMP.
+typedef union {
+    struct {
+        uint32_t prio_entry  : 16;          // Indicate the supported number of RRID in the instance
+        uint32_t rrid_transl : 16;          // Indicate the supported number of entries in the instance
+    };
+    uint32_t raw;
+} hwcfg2_t;
+
+// ENTRYOFFSET register ndicates the internal address
+// offsets of each table.
+typedef union {
+    struct {
+        uint32_t offset;                    // Indicate the offset address of the IOPMP array from the base
+                                            // of an IOPMP instance, a.k.a. the address of VERSION.
+                                            // Note: the offset is a signed number. That is, the IOPMP array
+                                            // can be placed in front of VERSION.
+    };
+    uint32_t raw;
+} entryoffset_t;
+
+#if (IOPMP_STALL_EN)
+// MDSTALL is an optional register and used to support
+// atomicity issue while programming the IOPMP, as the IOPMP
+// rule may not be updated in a single transaction.
+typedef union {
+    struct {
+        uint32_t exempt : 1;                    // Stall transactions with exempt selected MDs, or Stall selected MDs.
+        uint32_t md     : 31;                   // Writting md[i]=1 selects MD i; reading md[i] = 1 means MD i selected.
+    };
+    struct {
+        uint32_t is_stalled : 1;                // After the last writing of MDSTALL (included) plus any following writing RRIDSCP, 1
+                                                // indicates that all requested stalls take effect; otherwise, 0. After the last writing
+                                                // MDSTALLH (if any) and then MDSTALL by zero, 0 indicates that all transactions have
+                                                // been resumed; otherwise, 1.
+    };
+    uint32_t raw;
+} mdstall_t;
+
+// MDSTALLH is an optional register implemented along with MDSTALL
+// to support upto 63 memory domains (MDs) while programming the IOPMP
+typedef union {
+    struct {
+        uint32_t mdh : 32;                  // Writting mdh[i]=1 selects MD i+31;
+                                            // reading mdh[i] = 1 means MD i+31 selected.
+    };
+    uint32_t raw;
+} mdstallh_t;
+
+// RRIDSCP is an optional register and used to support
+// atomicity issue while programming the IOPMP, as the IOPMP
+// rule may not be updated in a single transaction.
+typedef union {
+    struct {
+        uint32_t rrid : 16;                 // Stall transactions with exempt selected MDs, or Stall selected MDs.
+        uint32_t rsv  : 14;                 // Reserved for future use.
+        uint32_t op   : 2;                  // 0x0: query
+                                            // 0x1: stall transactions associated with selected RRID
+                                            // 0x2: don’t stall transactions associated with selected RRID
+                                            // 0x3: reserved
+    };
+    struct {
+        uint32_t rsv1 : 30;                 // Stat is ready-only and located at 31:30
+        uint32_t stat : 2;                  // 0: RRIDSCP not implemented
+                                            // 1: transactions associated with selected RRID are stalled
+                                            // 2: transactions associated with selected RRID are not stalled
+                                            // 3: unimplemented or unselectable RRID
+    };
+    uint32_t raw;
+} rridscp_t;
+#endif
+
+#if (SRCMD_FMT != 1)
+// MDLCK is an optional register with a bitmap field to
+// indicate which MDs are locked in SRCMD table.
+typedef union {
+    struct {
+        uint32_t l  : 1;                    // Lock bit to MDLCK and MDLCKH register.
+        uint32_t md : 31;                   // md[j] = 1, indicates MD j is locked
+                                            // for all source memory domain table entries.
+    };
+    uint32_t raw;
+} mdlck_t;
+
+// MDLCKH is an optional register implemented along
+// with MDLCK to support upto 63 memory domains (MDs),
+typedef union {
+    struct {
+        uint32_t mdh : 31;                  // md[j] = 1, indicates MD j+31 is locked
+                                            // for all source memory domain table entries.
+    };
+    uint32_t raw;
+} mdlckh_t;
+
+#endif
+
+#if (MDCFG_FMT == 0)
+// MDCFGLCK is the lock register to MDCFG table.
+typedef union {
+    struct {
+        uint32_t l   : 1;                   // ock bit to MDCFGLCK register.
+        uint32_t f   : 7;                   // Indicate the number of locked MDCFG entries
+                                            // MDCFG(i) is locked for i < f.
+        uint32_t rsv : 24;                  // Reserved for future use
+    };
+    uint32_t raw;
+} mdcfglck_t;
+
+#endif
+
+// ENTRYLCK is the lock register to Entry table.
+typedef union {
+    struct {
+        uint32_t l   : 1;                   // ock bit to ENTRYLCK register.
+        uint32_t f   : 16;                  // Indicate the number of locked IOPMP entries
+                                            // NTRY_ADDR(i), ENTRY_ADDRH(i), ENTRY_CFG(i), and
+                                            // ENTRY_USER_CFG(i) are locked for i < f.
+        uint32_t rsv : 15;                  // Reserved for future use
+    };
+    uint32_t raw;
+} entrylck_t;
+
+// ERR_CFG is a read/write WARL register used to
+// configure the global error reporting behavior on an
+// IOPMP violation.
+typedef union {
+    struct {
+        uint32_t l       : 1;              // Lock fields to ERR_CFG register
+        uint32_t ie      : 1;              // Enable the interrupt of the IOPMP
+        uint32_t rs      : 1;              // To suppress an error response on an IOPMP rule violation.
+                                           // • 0x0: respond an implementation-dependent error, such as a bus error
+                                           // • 0x1: respond a success with a pre-defined value to the requestor instead of an error
+        uint32_t msi_en  : 1;              // It indicates whether the IOPMP triggers MSI
+        uint32_t rsv1    : 4;              // reserved for future use
+        uint32_t msidata : 11;             // The data to trigger MSI
+
+        uint32_t rsv2    : 13;             // reserved for future use
+    };
+    uint32_t raw;
+} err_cfg_t;
+
+// ERR_REQINFO captures more detailed error infomation.
+typedef union {
+    struct {
+        uint32_t v     : 1;                 // Indicate if the illegal capture recorder register has a
+                                            // valid content and will keep the content until the bit is cleared
+
+        uint32_t ttype : 2;                 // Indicates the transaction type
+                                            // 0x00 = reserved
+                                            // 0x01 = read access
+                                            // 0x02 = write access
+                                            // 0x03 = instruction fetch
+
+        uint32_t rsv1  : 1;                 // reserved for future use
+
+        uint32_t etype : 3;                 // Indicates the type of violation
+                                            // 0x00 = no error
+                                            // 0x01 = illegal read access
+                                            // 0x02 = illegal write access
+                                            // 0x03 = illegal instruction fetch
+                                            // 0x04 = partial hit on a priority rule
+                                            // 0x05 = not hit any rule
+                                            // 0x06 = unknown RRID
+                                            // 0x07 = user-defined error
+
+        uint32_t svc   : 1;                 // Indicate there is a subsequent violation caught in ERR_MFR.
+                                            // Implemented only for HWCFG0.mfr_en=1,
+
+        uint32_t rsv2  : 24;                // reserved for future use
+    };
+    uint32_t raw;
+} err_reqinfo_t;
+
+// ERR_REQADDR indicate the errored request address.
+typedef union {
+    struct {
+        uint32_t addr;                      // Indicate the errored address[33:2]
+    };
+    uint32_t raw;
+} err_reqaddr_t;
+
+// ERR_REQADDRH indicate the errored request address.
+typedef union {
+    struct {
+        uint32_t addrh;                     // Indicate the errored address[65:34]
+    };
+    uint32_t raw;
+} err_reqaddrh_t;
+
+// ERR_REQID indicates the errored RRID and entry index.
+typedef union {
+    struct {
+        uint32_t rrid : 16;                 // Indicate the errored RRID
+        uint32_t eid  : 16;                 // Indicates the index pointing to the entry that catches
+                                            // the violation. If no entry is hit, i.e., etype=0x05,
+                                            // the value of this field is invalid.
+                                            // If the field is not implemented, it should be wired to 0xffff.
+    };
+    uint32_t raw;
+} err_reqid_t;
+
+// ERR_MFR is an optional register. If Multi-Faults Record Extension
+// is enabled (HWCFG0.mfr_en=1),ERR_MFR can be used to retrieve
+// which RRIDs make subsequent violations.
+typedef union {
+    struct {
+        uint32_t svw : 16;                  // Subsequent violations in the window indexed by svi
+
+        uint32_t svi : 12;                  // Window’s index to search subsequent violations.
+                                            // When read, svi moves forward until one subsequent violation
+                                            // is found or svi has been rounded back to the same value
+
+        uint32_t rsv : 3;                   // reserved for future use
+
+        uint32_t svs : 1;                   // the status of this window’s content:
+                                            // 0x0 = no subsequent violation found
+                                            // 0xq = subsequent violation found
+    };
+    uint32_t raw;
+} err_mfr_t;
+
+// MSI Data Address register
+typedef union {
+    struct {
+        uint32_t msiaddr;                      // Indicate the msi address[33:2]
+    };
+    uint32_t raw;
+} err_msiaddr_t;
+
+// MSI Data Address register
+typedef union {
+    struct {
+        uint32_t msiaddrh;                     // Indicate the msi address[65:34]
+    };
+    uint32_t raw;
+} err_msiaddrh_t;
+
+// ERR_USER are optional registers (0, 1,... 8) to provide users to
+// define their own error capture information
+typedef union {
+    struct {
+        uint32_t user : 32;                 // Indicate the errored address[65:34]
+    };
+    uint32_t raw;
+} err_user_t;
+
+#if (MDCFG_FMT == 0)
+
+// MDCFG table is a lookup to specify the number of IOPMP entries
+// that is associated with each MD. number of MDCFG registers is equal
+// to HWCFG0.md_num, all MDCFG registers are readable and writable
+typedef union {
+    struct {
+        uint32_t t   : 16;                  // Indicate the top range of memory domain m.
+                                            // An IOPMP entry with index j belongs to MD m
+
+        uint32_t rsv : 16;                  // REserved for future use
+    };
+    uint32_t raw;
+} mdcfg_t;
+
+#endif
+
+#if (SRCMD_FMT == 0)
+// SRCMD_EN register (0, .... , HWCFG1.rrid_num-1) is a specific register
+// for each source (RRID) and indicates which MDs this source maps to
+typedef union {
+    struct {
+        uint32_t l  : 1;                    // A sticky lock bit. When set, locks SRCMD_EN(s), SRCMD_ENH(s),
+                                            // SRCMD_R(s), SRCMD_RH(s), SRCMD_W(s),
+
+        uint32_t md : 31;                   // md[j] = 1 indicates MD j is associated with RRID s.
+    };
+    uint32_t raw;
+} srcmd_en_t;
+
+// SRCMD_ENH register (0, .... , HWCFG1.rrid_num-1) is a specific register
+// for each source (RRID) and indicates which MDs this source maps to
+typedef union {
+    struct {
+        uint32_t mdh : 32;                  // mdh[i]=1 indicates MD i+31 is associated with RRID;
+    };
+    uint32_t raw;
+} srcmd_enh_t;
+
+// SRCMD_R register (0, .... , HWCFG1.rrid_num-1) is a optional
+// specific register for each source (RRID) and indicates which MDs
+// has read permissions.
+typedef union {
+    struct {
+        uint32_t rsv : 1;                   // Reserved for future use
+        uint32_t md  : 31;                  // md[j] = 1 indicates RRID s has read permission to
+                                            // the corresponding MD
+    };
+    uint32_t raw;
+} srcmd_r_t;
+
+// SRCMD_RH register (0, .... , HWCFG1.rrid_num-1) is a optional
+// specific register for each source (RRID) and indicates which MDs
+// has read permissions.
+typedef union {
+    struct {
+        uint32_t mdh : 32;                  // md[j] = 1 indicates RRID s has read permission to
+                                            // the corresponding MD j+31
+    };
+    uint32_t raw;
+} srcmd_rh_t;
+
+// SRCMD_W register (0, .... , HWCFG1.rrid_num-1) is a optional
+// specific register for each source (RRID) and indicates which MDs
+// has write permissions.
+typedef union {
+    struct {
+        uint32_t rsv : 1;                   // Reserved for future use
+        uint32_t md  : 31;                  // md[j] = 1 indicates RRID s has write permission to
+                                            // the corresponding MD
+    };
+    uint32_t raw;
+} srcmd_w_t;
+
+// SRCMD_WH register (0, .... , HWCFG1.rrid_num-1) is a optional
+// specific register for each source (RRID) and indicates which MDs
+// has write permissions.
+typedef union {
+    struct {
+        uint32_t mdh : 32;                  // md[j] = 1 indicates RRID s has write permission to
+                                            // the corresponding MD j+31
+    };
+    uint32_t raw;
+} srcmd_wh_t;
+
+#endif
+
+#if (SRCMD_FMT == 2)
+
+typedef union {
+    struct {
+        uint32_t perm  : 32;
+    };
+    uint32_t raw;
+} srcmd_perm_t;
+
+typedef union {
+    struct {
+        uint32_t permh  : 32;
+    };
+    uint32_t raw;
+} srcmd_permh_t;
+
+#endif
+
+#if (SRCMD_FMT != 1)
+// SRCMD Table contains HWCFG1.rrid_num-1 groups of registers
+typedef struct {
+#if (SRCMD_FMT == 0)
+    srcmd_en_t  srcmd_en;
+    srcmd_enh_t srcmd_enh;
+    srcmd_r_t   srcmd_r;
+    srcmd_rh_t  srcmd_rh;
+    srcmd_w_t   srcmd_w;
+    srcmd_wh_t  srcmd_wh;
+    uint32_t    rsvd[2];
+#elif (SRCMD_FMT == 2)
+    srcmd_perm_t  srcmd_perm;
+    srcmd_permh_t srcmd_permh;
+    uint32_t      rsvd[6];
+#endif
+} srcmd_table_t;
+
+#endif
+
+// ENTRY_ADDR registers (0, ..... HWCFG1.entry_num-1) holds physical address
+// of protected memory region
+typedef union {
+    struct {
+        uint32_t addr : 32;                 // The physical address[33:2] of protected memory region.
+    };
+    uint32_t raw;
+} entry_addr_t;
+
+// ENTRY_ADDRH register (0, ..... HWCFG1.entry_num-1) holds physical address
+// of protected memory region.
+// it is implemented to support wider physical addresses However, an IOPMP
+// can only manage a segment of space, so an implementation would have a certain
+// number of the most significant bits that are the same among all entries.
+// These bits are allowed to be hardwired.
+typedef union {
+    struct {
+        uint32_t addrh : 32;                // The physical address[65:43] of protected memory region.
+    };
+    uint32_t raw;
+} entry_addrh_t;
+
+// ENTRY_CFG register (0, ..... HWCFG1.entry_num-1) holds permissions
+// related to protected meomory region (IOPMP entry)
+// These entries are used to validate the requested permissions.
+typedef union {
+    struct {
+        uint32_t r    : 1;                  // The read permission to protected memory region
+
+        uint32_t w    : 1;                  // The write permission to the protected memory region
+
+        uint32_t x    : 1;                  // The instruction fetch permission to the protected memory region.
+                                            // Optional field, if unimplemented, write any read the same value
+                                            // as r field.
+
+        uint32_t a    : 2;                  // The address mode of the IOPMP entry
+                                            // 0x0: OFF
+                                            // 0x1: TOR
+                                            // 0x2: NA4
+                                            // 0x3: NAPOT
+
+        uint32_t sire : 1;                  // To suppress interrupt for an illegal read access caught by the entry
+        uint32_t siwe : 1;                  // Suppress interrupt for write violations caught by the entry
+        uint32_t sixe : 1;                  // Suppress interrupt on an illegal instruction fetch caught by the entry
+        uint32_t sere : 1;                  // Supress the (bus) error on an illegal read access caught by the entry
+                                            // 0x0: the response by ERR_CFG.rre
+                                            // 0x1: do not respond an error. User to define the behavior,
+                                            //      e.g., respond a success with an implementation-dependent
+                                            //      value to the requestor.
+
+        uint32_t sewe : 1;                  // Supress the (bus) error on an illegal write access caught by the entry
+                                            //• 0x0: the response by ERR_CFG.rwe
+                                            //• 0x1: do not respond an error. User to define the behavior,
+                                            //       e.g., respond a success if response is needed
+        uint32_t sexe : 1;                  //       upress the (bus) error on an illegal instruction fetch
+                                            //       caught by the entry
+                                            // 0x0: the response by ERR_CFG.rxe
+                                            // 0x1: do not respond an error. User to define the behavior,
+                                            //      e.g., respond a success with an implementation-dependent
+                                            //      value to the requestor.
+        uint32_t rsv  : 21;                 // Must be zero on write, reserved for future
+    };
+    uint32_t raw;
+} entry_cfg_t;
+
+// ENTRY_USER_CFG implementation defined registers (0, ..... HWCFG1.entry_num-1)
+// that allows users to define their own additional IOPMP check
+// rules beside the rules defined in ENTRY_CFG.
+typedef union {
+    struct {
+        uint32_t im;                        // reserved for future use
+    };
+    uint32_t raw;
+} entry_user_cfg_t;
+
+// IOPMP Entry Table contains HWCFG1.rrid_num-1 groups of register
+typedef struct {
+    entry_addr_t     entry_addr;
+    entry_addrh_t    entry_addrh;
+    entry_cfg_t      entry_cfg;
+    entry_user_cfg_t entry_user_cfg;
+} entry_table_t;
+
+// IOPMP Paked register map
+typedef union {
+    struct __attribute__((__packed__)) {
+        version_t        version;
+        implementation_t implementation;
+        hwcfg0_t         hwcfg0;
+        hwcfg1_t         hwcfg1;
+        hwcfg2_t         hwcfg2;
+        entryoffset_t    entryoffset;
+        uint32_t         reserved0[6];
+        #if (IOPMP_STALL_EN)
+        mdstall_t        mdstall;
+        mdstallh_t       mdstallh;
+        rridscp_t        rridscp;
+        #else
+        uint32_t         reserved7[3];
+        #endif
+        uint32_t         reserved1[1];
+        #if (SRCMD_FMT != 1)
+        mdlck_t          mdlck;
+        mdlckh_t         mdlckh;
+        #else
+        uint32_t         reserved6[2];
+        #endif
+        #if (MDCFG_FMT == 0)
+        mdcfglck_t       mdcfglck;
+        #else
+        uint32_t         reserved8;
+        #endif
+        entrylck_t       entrylck;
+        uint32_t         reserved2[4];
+        err_cfg_t        err_cfg;
+        err_reqinfo_t    err_reqinfo;
+        err_reqaddr_t    err_reqaddr;
+        err_reqaddrh_t   err_reqaddrh;
+        err_reqid_t      err_reqid;
+        err_mfr_t        err_mfr;
+        #if (MSI_EN)
+        err_msiaddr_t    err_msiaddr;
+        err_msiaddrh_t   err_msiaddrh;
+        #else
+        uint32_t         reserved9[2];
+        #endif
+        err_user_t       err_user[8];
+        uint32_t         reserved4[472];
+        #if (MDCFG_FMT == 0)
+        mdcfg_t          mdcfg[IOPMP_MD_NUM];
+        uint32_t         reserved5[(SRCMD_TABLE_BASE_OFFSET - (MDCFG_TABLE_BASE_OFFSET + (IOPMP_MD_NUM * 4))) / 4];
+        #else
+        uint32_t         reserved5[(SRCMD_TABLE_BASE_OFFSET - MDCFG_TABLE_BASE_OFFSET) / 4];
+        #endif
+        #if (SRCMD_FMT == 0)
+        srcmd_table_t    srcmd_table[IOPMP_RRID_NUM];
+        #elif (SRCMD_FMT == 2)
+        srcmd_table_t    srcmd_table[IOPMP_MD_NUM];
+        #endif
+    };
+    uint32_t        regs4[2048];
+    uint64_t        regs8[2048/2];
+} iopmp_regs_t;
+
+typedef union {
+    struct __attribute__((__packed__)) {
+        entry_table_t    entry_table[IOPMP_ENTRY_NUM];
+    };
+    uint32_t        regs4[(IOPMP_ENTRY_NUM * 16) + 4];
+    uint64_t        regs8[((IOPMP_ENTRY_NUM * 16) + 4)/2];
+} iopmp_entries_t;
+
+typedef struct {
+    err_mfr_t sv[IOPMP_RRID_NUM];
+} err_mfrs_t;
+
+#endif

--- a/iopmp_ref_model/include/iopmp_req_rsp.h
+++ b/iopmp_ref_model/include/iopmp_req_rsp.h
@@ -1,5 +1,6 @@
 /***************************************************************************
 // Author: Yazan Hussnain (yazan.hussain@10xengineers.ai)
+//         Gull Ahmed (gull.ahmed@10xengineers.ai)
 // Date: October 21, 2024
 // Description: IOPMP Request Response Structure
 // This header file defines data structures and enumerations used in the
@@ -24,7 +25,7 @@ typedef enum {
 } perm_type_e;
 
 // Structure for IOPMP transaction requests
-typedef struct {
+typedef struct __attribute__((__packed__)) {
     uint16_t    rrid;      // Requester ID
     uint64_t    addr;      // Target address for the transaction
     uint32_t    length;    // Length of the transaction
@@ -46,12 +47,13 @@ typedef enum {
     PARTIAL_HIT_ON_PRIORITY= 0x04,  // Partial hit on a priority entry
     NOT_HIT_ANY_RULE       = 0x05,  // No rule matched the transaction
     UNKNOWN_RRID           = 0x06,  // Unknown requester ID in transaction
+    STALLED_TRANSACTION    = 0x07,  // Error due to a stalled transaction
     ENTRY_MATCH            = 0x10,  // Entry matched in access control
     ENTRY_NOTMATCH         = 0x11   // No matching entry found
 } iopmpMatchStatus_t;
 
 // Structure for IOPMP transaction responses
-typedef struct {
+typedef struct __attribute__((__packed__)) {
     uint32_t rrid;          // Requester ID
     uint8_t  user;          // User mode indicator
     uint8_t  rrid_stalled;  // Requester ID stall status

--- a/iopmp_ref_model/include/iopmp_req_rsp.h
+++ b/iopmp_ref_model/include/iopmp_req_rsp.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+// Author: Yazan Hussnain (yazan.hussain@10xengineers.ai)
+// Date: October 21, 2024
+// Description: IOPMP Request Response Structure
+// This header file defines data structures and enumerations used in the
+// Input/Output Physical Memory Protection (IOPMP) for handling request
+// and response transactions. It includes the enumeration of permission
+// types (read, write, and instruction fetch) and status codes, as well
+// as detailed request and response structures for transactions. These
+// definitions help to manage access control, track transaction details,
+// and capture any errors that occur during access attempts.
+***************************************************************************/
+
+#include "iopmp.h"
+
+#ifndef __IOPMP_REQ_RSP_H__
+#define __IOPMP_REQ_RSP_H__
+
+// Enumerates transaction types (read, write, instruction fetch)
+typedef enum {
+    READ_ACCESS  = 1,  // Read permission
+    WRITE_ACCESS = 2,  // Write permission
+    INSTR_FETCH  = 3   // Instruction fetch permission
+} perm_type_e;
+
+// Structure for IOPMP transaction requests
+typedef struct {
+    uint16_t    rrid;      // Requester ID
+    uint64_t    addr;      // Target address for the transaction
+    uint32_t    length;    // Length of the transaction
+    uint32_t    size;      // Size of each access in the transaction
+    perm_type_e perm;      // Type of permission requested
+} iopmp_trans_req_t;
+
+// Enumerates status results for IOPMP transactions
+typedef enum {
+    IOPMP_SUCCESS = 0,  // Transaction successful
+    IOPMP_ERROR   = 1   // Transaction encountered an error
+} status_e;
+
+// Enumerates specific match and error statuses for transactions
+typedef enum {
+    ILLEGAL_READ_ACCESS    = 0x01,  // Illegal read access attempted
+    ILLEGAL_WRITE_ACCESS   = 0x02,  // Illegal write access attempted
+    ILLEGAL_INSTR_FETCH    = 0x03,  // Illegal instruction fetch attempted
+    PARTIAL_HIT_ON_PRIORITY= 0x04,  // Partial hit on a priority entry
+    NOT_HIT_ANY_RULE       = 0x05,  // No rule matched the transaction
+    UNKNOWN_RRID           = 0x06,  // Unknown requester ID in transaction
+    ENTRY_MATCH            = 0x10,  // Entry matched in access control
+    ENTRY_NOTMATCH         = 0x11   // No matching entry found
+} iopmpMatchStatus_t;
+
+// Structure for IOPMP transaction responses
+typedef struct {
+    uint32_t rrid;          // Requester ID
+    uint8_t  user;          // User mode indicator
+    uint8_t  rrid_stalled;  // Requester ID stall status
+#if (IOPMP_RRID_TRANSL_EN)
+    uint16_t rrid_transl;
+#endif
+    status_e status;        // Transaction status (success or error)
+} iopmp_trans_rsp_t;
+
+#endif

--- a/iopmp_ref_model/src/iopmp_error_capture.c
+++ b/iopmp_ref_model/src/iopmp_error_capture.c
@@ -1,0 +1,61 @@
+/***************************************************************************
+// Author: Yazan Hussnain (yazan.hussain@10xengineers.ai)
+// Date: October 24, 2024
+// Description: IOPMP Error Capture Module
+// This file contains the implementation for error capturing in the
+// Input/Output Physical Memory Protection (IOPMP). The `errorCapture`
+// function is responsible for logging error information when a transaction
+// request encounters an access violation or permission-related issue. It
+// stores details such as transaction type, error type, request ID, entry ID,
+// and the address where the error occurred. Additionally, the function
+// detects and flags subsequent violations and can trigger an interrupt if
+// necessary.
+***************************************************************************/
+
+#include "iopmp.h"
+
+/**
+  * @brief Captures and logs error information for a transaction request.
+  *
+  * @param trans_type Type of the transaction request (read/write permissions).
+  * @param error_type Specific error type encountered during the transaction.
+  * @param rrid Requester ID associated with the transaction.
+  * @param entry_id IOPMP entry ID where the error was encountered.
+  * @param err_addr Address at which the error occurred.
+  * @param intrpt Pointer to an interrupt flag, which is set if an error is captured.
+ **/
+void errorCapture(perm_type_e trans_type, uint8_t error_type, uint16_t rrid, uint16_t entry_id, uint64_t err_addr, uint8_t *intrpt) {
+    int err_reqinfo_v = g_reg_file.err_reqinfo.v;
+    // If no error has been logged and interrupt and error both are not suppressed, capture error details
+    if (!g_reg_file.err_reqinfo.v && (!error_suppress | !intrpt_suppress)) {
+        g_reg_file.err_reqinfo.v     = 1;               // Mark error as captured
+        // Set error status and transaction details
+        g_reg_file.err_reqinfo.ttype = trans_type;      // Transaction type (read/write)
+        g_reg_file.err_reqinfo.etype = error_type;      // Specific error type
+
+        // Capture lower and upper parts of error address
+        g_reg_file.err_reqaddr.addr   = (uint32_t)((err_addr >> 2) & UINT32_MAX);         // Error address [33:2]
+        g_reg_file.err_reqaddrh.addrh = (uint32_t)((err_addr >> 34) & UINT32_MAX);        // Error address [65:34]
+
+        // Record Request ID and Entry ID details
+        g_reg_file.err_reqid.rrid = rrid;
+        g_reg_file.err_reqid.eid  = entry_id;
+
+    // If an error was previously logged, handle a subsequent violation
+    } else if ((err_svs.sv[rrid].svw != MAX_SVS) && g_reg_file.hwcfg0.mfr_en && (!error_suppress | !intrpt_suppress)) {
+        // Update violation window counter
+        err_svs.sv[rrid].svw |= (err_svs.sv[rrid].svw + 1);  // Increment violation count
+    }
+
+    // Check for any subsequent violation and set err_reqinfo.svc
+    for (int i = 0; i < IOPMP_RRID_NUM; i++) {
+        if (err_svs.sv[i].svw) {
+            g_reg_file.err_reqinfo.svc = 1;
+            break;
+        }
+    }
+    
+    // Generate Interrupt
+    if (!err_reqinfo_v)
+        generate_interrupt(intrpt);
+}

--- a/iopmp_ref_model/src/iopmp_interrupt.c
+++ b/iopmp_ref_model/src/iopmp_interrupt.c
@@ -1,0 +1,50 @@
+
+/***************************************************************************
+// Author: Yazan Hussnain (yazan.hussain@10xengineers.ai)
+// Date: October 24, 2024
+// Description: IOPMP Interrupt Generation
+// When interrupt generation is valid, this function is used to generate
+// WSI or MSI based on the configuration in ERR_CFG register. This also
+// check for the interrrupt suppression.
+***************************************************************************/
+
+#include "iopmp.h"
+
+/**
+ * @brief Generate an interrupt based on configuration and suppress flag.
+ *
+ * This function checks if interrupts are enabled and not suppressed. If MSI (Message Signaled Interrupt)
+ * is disabled, it generates a wired signal interrupt. When MSI is enabled, it constructs the MSI address
+ * and data, writes them to memory, and handles any potential bus errors during the write operation.
+ *
+ * @param intrpt Pointer to a variable to store the interrupt flag.
+ */
+void generate_interrupt(uint8_t *intrpt) {
+    // Extract configuration values for clarity
+    const uint8_t msi_enabled = g_reg_file.err_cfg.msi_en;
+    const uint8_t interrupt_enabled = g_reg_file.err_cfg.ie;
+    *intrpt = 0;
+    // Check if interrupts are not enabled
+    if (interrupt_enabled) {
+        // Check if interrupts are not suppressed
+        if (!intrpt_suppress) {
+            *intrpt = !msi_enabled;
+            #if (MSI_EN)
+                if (msi_enabled) {
+                    // Construct MSI address and data for enabled MSI.
+                    // {MSI_ADDRH[64:34], MSI_ADDR[33:2], 2'b00}
+                    uint64_t msi_addr = CONCAT32(g_reg_file.err_msiaddrh.raw,g_reg_file.err_msiaddr.raw) << 2;
+                    uint32_t msi_data = g_reg_file.err_cfg.msidata;
+                    // Write MSI data to memory
+                    uint8_t status = write_memory((char *)&msi_data, msi_addr, MSI_DATA_BYTE);
+
+                    // Handle bus errors during MSI write
+                    if (status & BUS_ERROR) {
+                        // TODO: Add specific error-handling logic here
+                        return;
+                    }
+                }
+            #endif
+        }
+    }
+}

--- a/iopmp_ref_model/src/iopmp_interrupt.c
+++ b/iopmp_ref_model/src/iopmp_interrupt.c
@@ -1,6 +1,7 @@
 
 /***************************************************************************
 // Author: Yazan Hussnain (yazan.hussain@10xengineers.ai)
+//         Gull Ahmed (gull.ahmed@10xengineers.ai)
 // Date: October 24, 2024
 // Description: IOPMP Interrupt Generation
 // When interrupt generation is valid, this function is used to generate
@@ -30,18 +31,21 @@ void generate_interrupt(uint8_t *intrpt) {
         if (!intrpt_suppress) {
             *intrpt = !msi_enabled;
             #if (MSI_EN)
-                if (msi_enabled) {
+                if (msi_enabled && !g_reg_file.err_info.msi_werr) {
                     // Construct MSI address and data for enabled MSI.
                     // {MSI_ADDRH[64:34], MSI_ADDR[33:2], 2'b00}
-                    uint64_t msi_addr = CONCAT32(g_reg_file.err_msiaddrh.raw,g_reg_file.err_msiaddr.raw) << 2;
-                    uint32_t msi_data = g_reg_file.err_cfg.msidata;
+                    #if (IOPMP_ADDRH_EN)
+                        uint64_t msi_addr = CONCAT32(g_reg_file.err_msiaddrh.raw, g_reg_file.err_msiaddr.raw);
+                    #else
+                        uint64_t msi_addr = CONCAT32(0, g_reg_file.err_msiaddr.raw << 2);
+                    #endif
+                    uint64_t msi_data = g_reg_file.err_cfg.msidata;
                     // Write MSI data to memory
-                    uint8_t status = write_memory((char *)&msi_data, msi_addr, MSI_DATA_BYTE);
+                    uint8_t status = write_memory(&msi_data, msi_addr, MSI_DATA_BYTE);
 
                     // Handle bus errors during MSI write
-                    if (status & BUS_ERROR) {
-                        // TODO: Add specific error-handling logic here
-                        return;
+                    if (status == BUS_ERROR) {
+                        g_reg_file.err_info.msi_werr = 1;
                     }
                 }
             #endif

--- a/iopmp_ref_model/src/iopmp_reg.c
+++ b/iopmp_ref_model/src/iopmp_reg.c
@@ -1,0 +1,742 @@
+/***************************************************************************
+// Author: Gull Ahmed (gull.ahmed@10xengineers.ai)
+//         Yazan Hussnain (yazan.hussain@10xengineers.ai)
+// Date: October 21, 2024
+// Description: 
+// This file implements the IOPMP (I/O Physical Memory Protection)
+// functions to read/write and reset the MMAP Registers.
+//
+// The main functions in this file include:
+// - reset_iopmp: Resets the I/O Physical Memory Protection (IOPMP) 
+//   configuration registers to default values.
+// - is_access_valid: Checks if the access to a given offset and number 
+//   of bytes is valid.
+// - read_register: Reads a register based on the given offset and byte size.
+// - rrid_stall_update: Updates the stall status for each RRID based on 
+//   memory domain stall conditions.
+// - write_register: Writes data to a memory-mapped register identified 
+//   by the specified offset.
+***************************************************************************/
+
+#include "iopmp.h"
+#include "config.h"
+
+int rrid_stall[IOPMP_RRID_NUM];
+
+/**
+ * @brief Resets the I/O Physical Memory Protection (IOPMP) configuration
+ * registers to default values.
+ *
+ * This function initializes all configuration in the IOPMP module,
+ * setting them to their default values. It also conditionally applies
+ * certain configurations based on compile-time macros (e.g., `MDCFG_FMT`,
+ * `SRCMD_FMT`) to enable or disable specific features, making it
+ * adaptable to various IOPMP configurations.
+ *
+ * This reset function ensures that the IOPMP module is in a known, clean state,
+ * ideal for initialization before a new configuration is loaded.
+ *
+ * @return it Returns 0 upon successful reset.
+ */
+
+// Function to reset I/O Memory Protection
+int reset_iopmp() {
+
+    // Reset all IOPMP registers
+    g_reg_file.version.vendor          = 1;     // Set vendorID
+    g_reg_file.version.specver         = 1;     // Set IOPMP Specification version
+    g_reg_file.implementation.raw      = 0;     // Set implementationID
+
+    // Set the MDCFG Format - Based on compiled model
+#ifdef MDCFG_FMT
+    g_reg_file.hwcfg0.mdcfg_fmt        = MDCFG_FMT;
+#endif
+
+    // Set the SRCMD Format - Based on compiled model
+#ifdef SRCMD_FMT
+    g_reg_file.hwcfg0.srcmd_fmt        = SRCMD_FMT;
+#endif
+
+    // Hardware Configuration
+    g_reg_file.hwcfg0.tor_en           = IOPMP_TOR_EN;
+    g_reg_file.hwcfg0.sps_en           = IOPMP_SPS_EN;
+    g_reg_file.hwcfg0.user_cfg_en      = 0;
+    g_reg_file.hwcfg0.prient_prog      = IOPMP_PARIENT_PROG;
+    g_reg_file.hwcfg0.rrid_transl_en   = IOPMP_RRID_TRANSL_EN;
+    g_reg_file.hwcfg0.rrid_transl_prog = IOPMP_RRID_TRANSL_PROG;
+    g_reg_file.hwcfg0.chk_x            = IOPMP_CHK_X;
+    g_reg_file.hwcfg0.no_x             = IOPMP_NO_X;
+    g_reg_file.hwcfg0.no_w             = IOPMP_NO_W;
+    g_reg_file.hwcfg0.stall_en         = IOPMP_STALL_EN;
+    g_reg_file.hwcfg0.peis             = IOPMP_PEIS;
+    g_reg_file.hwcfg0.pees             = IOPMP_PEES;
+    g_reg_file.hwcfg0.mfr_en           = IOPMP_MFR_EN;
+
+#if (MDCFG_FMT == 0)
+    g_reg_file.hwcfg0.md_entry_num     = 0;
+#else
+    g_reg_file.hwcfg0.md_entry_num     = IOPMP_MD_ENTRY_NUM;
+#endif
+
+    g_reg_file.hwcfg0.md_num           = IOPMP_MD_NUM;
+    g_reg_file.hwcfg0.addrh_en         = IOPMP_ADDRH_EN;
+    g_reg_file.hwcfg0.enable           = IOPMP_ENABLE;
+
+    g_reg_file.hwcfg1.rrid_num         = IOPMP_RRID_NUM;
+    g_reg_file.hwcfg1.entry_num        = IOPMP_ENTRY_NUM;
+
+    g_reg_file.hwcfg2.prio_entry       = IOPMP_PRIO_ENTRY;
+#if (IOPMP_RRID_TRANSL_EN)
+    g_reg_file.hwcfg2.rrid_transl      = IOPMP_RRID_TRANSL;
+#else
+    g_reg_file.hwcfg2.rrid_transl      = 0;
+#endif
+
+    g_reg_file.entryoffset.raw         = ENTRY_OFFSET;
+
+#if (IOPMP_STALL_EN)
+    g_reg_file.mdstall.raw             = 0;
+    g_reg_file.mdstallh.raw            = 0;
+    g_reg_file.rridscp.raw             = 0;
+#else
+    for (size_t i = 0; i < sizeof(g_reg_file.reserved7) / sizeof(g_reg_file.reserved7[0]); i++) {
+        g_reg_file.reserved7[i] = 0;
+    }
+#endif
+
+#if (SRCMD_FMT != 1)
+    g_reg_file.mdlck.raw               = 0;
+    g_reg_file.mdlck.l                 = !IMP_MDLCK;
+    g_reg_file.mdlckh.raw              = 0;
+#else
+    for (size_t i = 0; i < sizeof(g_reg_file.reserved6) / sizeof(g_reg_file.reserved6[0]); i++) {
+        g_reg_file.reserved6[i] = 0;
+    }
+#endif
+
+#if (MDCFG_FMT == 0)
+    g_reg_file.mdcfglck.raw            = 0;
+#else
+    g_reg_file.reserved8               = 0;
+#endif
+
+    g_reg_file.entrylck.raw            = 0;
+    g_reg_file.err_cfg.raw             = 0;
+    g_reg_file.err_reqinfo.raw         = 0;
+    g_reg_file.err_reqaddr.raw         = 0;
+    g_reg_file.err_reqaddrh.raw        = 0;
+    g_reg_file.err_reqid.rrid          = 0;
+    g_reg_file.err_reqid.eid           = IMP_ERROR_REQID ? 0 : 0xFFFF;
+    g_reg_file.err_mfr.raw             = 0;
+
+#if (MSI_EN)
+    g_reg_file.err_msiaddr.raw         = 0;
+    g_reg_file.err_msiaddrh.raw        = 0;
+#else
+    for (size_t i = 0; i < sizeof(g_reg_file.reserved9) / sizeof(g_reg_file.reserved9[0]); i++) {
+        g_reg_file.reserved9[i] = 0;
+    }
+#endif
+
+    // Reset array fields using loops
+    // Reset array fields using loops with size_t for the index
+    for (size_t i = 0; i < sizeof(g_reg_file.reserved0) / sizeof(g_reg_file.reserved0[0]); i++) {
+        g_reg_file.reserved0[i] = 0;
+    }
+
+    for (size_t i = 0; i < sizeof(g_reg_file.reserved1) / sizeof(g_reg_file.reserved1[0]); i++) {
+        g_reg_file.reserved1[i] = 0;
+    }
+
+    for (size_t i = 0; i < sizeof(g_reg_file.reserved2) / sizeof(g_reg_file.reserved2[0]); i++) {
+        g_reg_file.reserved2[i] = 0;
+    }
+
+    for (size_t i = 0; i < sizeof(g_reg_file.err_user) / sizeof(g_reg_file.err_user[0]); i++) {
+        g_reg_file.err_user[i].raw = 0;
+    }
+
+#if (MDCFG_FMT == 0)
+    for (size_t i = 0; i < sizeof(g_reg_file.mdcfg) / sizeof(g_reg_file.mdcfg[0]); i++) {
+        g_reg_file.mdcfg[i].raw = 0;
+    }
+#endif
+
+    for (size_t i = 0; i < sizeof(g_reg_file.reserved4) / sizeof(g_reg_file.reserved4[0]); i++) {
+        g_reg_file.reserved4[i] = 0;
+    }
+
+#if (SRCMD_FMT == 0)
+    for (size_t i = 0; i < sizeof(g_reg_file.srcmd_table) / sizeof(g_reg_file.srcmd_table[0]); i++) {
+        g_reg_file.srcmd_table[i].srcmd_en.raw  = 0;
+        g_reg_file.srcmd_table[i].srcmd_enh.raw = 0;
+        g_reg_file.srcmd_table[i].srcmd_r.raw   = 0;
+        g_reg_file.srcmd_table[i].srcmd_rh.raw  = 0;
+        g_reg_file.srcmd_table[i].srcmd_w.raw   = 0;
+        g_reg_file.srcmd_table[i].srcmd_wh.raw  = 0;
+        g_reg_file.srcmd_table[i].rsvd[0]       = 0;
+        g_reg_file.srcmd_table[i].rsvd[1]       = 0;
+    }
+
+#elif (SRCMD_FMT == 2)
+    for (size_t i = 0; i < sizeof(g_reg_file.srcmd_table) / sizeof(g_reg_file.srcmd_table[0]); i++) {
+        g_reg_file.srcmd_table[i].srcmd_perm.raw  = 0;
+        g_reg_file.srcmd_table[i].srcmd_permh.raw = 0;
+        for (int j = 0; j < 6; j++) {
+            g_reg_file.srcmd_table[i].rsvd[j]       = 0;
+            g_reg_file.srcmd_table[i].rsvd[j]       = 0;
+        }
+    }
+#endif
+
+    for (size_t i = 0; i < sizeof(g_reg_file.reserved5) / sizeof(g_reg_file.reserved5[0]); i++) {
+        g_reg_file.reserved5[i] = 0;
+    }
+
+    for (size_t i = 0; i < sizeof(iopmp_entries.entry_table) / sizeof(iopmp_entries.entry_table[0]); i++) {
+        iopmp_entries.entry_table[i].entry_addr.raw     = 0;
+        iopmp_entries.entry_table[i].entry_addrh.raw    = 0;
+        iopmp_entries.entry_table[i].entry_cfg.raw      = 0;
+        iopmp_entries.entry_table[i].entry_user_cfg.raw = 0;
+    }
+    for (int i = 0; i < IOPMP_RRID_NUM; i++) {
+        err_svs.sv[i].raw = 0;
+    }
+    for (int i = 0; i < IOPMP_RRID_NUM; i++) {
+        rrid_stall[i] = 0;
+    }
+    intrpt_suppress = 0;
+    error_suppress  = 0;
+    return 0; // Success
+}
+
+/**
+  * @brief Checks if the access to a given offset and number of bytes is valid.
+  *
+  * @param offset     The offset within the memory map to check for access.
+  * @param num_bytes  The number of bytes requested for the access.
+  * @return uint8_t   Returns 1 if access is valid, 0 if invalid.
+ **/
+uint8_t is_access_valid(uint16_t offset, uint8_t num_bytes) {
+    // Check if the offset falls within the allowed IOPMP rule range
+    bool iopmpRule_range;
+    iopmpRule_range = (offset >= ENTRY_OFFSET) &
+                      (offset < ((ENTRY_OFFSET + 0xC) + (IOPMP_ENTRY_NUM * ENTRY_REG_STRIDE)));
+
+    // Validate the access by checking:
+    // 1. If the requested byte size is either 4 or 8.
+    // 2. If the offset is within the allowable range for valid RRIDs,
+    //    and if it is outside the range, ensure it falls within the IOPMP rule range.
+    // 3. If the offset is aligned with the requested byte size.
+    if ((num_bytes != 4 && num_bytes != 8) || (num_bytes > REG_INTF_BUS_WIDTH) ||
+        (offset >= (0x1014 + (IOPMP_RRID_NUM * 32)) && !iopmpRule_range) ||
+        ((offset & (num_bytes - 1)) != 0)) {
+        return 0; // Access is invalid
+    }
+
+    return 1; // Access is valid
+}
+
+/**
+ * @brief Reads a register based on the given offset and byte size.
+ *
+ * This function handles special cases for specific offsets (e.g., error registers)
+ * and returns the corresponding register value, either 4 or 8 bytes, based on the
+ * provided number of bytes.
+ *
+ * @param offset The offset of the register to be read.
+ * @param num_bytes The number of bytes to read (either 4 or 8 bytes).
+ *
+ * @return The value of the register in the appropriate size (4 or 8 bytes).
+ */
+reg_intf_dw read_register(uint16_t offset, uint8_t num_bytes) {
+
+    if (!is_access_valid(offset, num_bytes)) return 0;
+    // If the requested offset corresponds to the error MFR (ERR_MFR_OFFSET)
+    // handle reading from the error register.
+    if (offset == ERR_MFR_OFFSET) {
+        uint32_t err_mfr;
+
+        // Clear the error flags for error register.
+        g_reg_file.err_mfr.svs = 0;
+        g_reg_file.err_mfr.svw = 0;
+
+        // Start searching for errors from the current error index.
+        int start_index = g_reg_file.err_mfr.svi;
+
+        // Loop over the RRIDs to find any error state.
+        for (int i = 0; i < IOPMP_RRID_NUM; i++) {
+            // Calculate the current index, with wrap-around using modulo.
+            int current_index = (start_index + i) % IOPMP_RRID_NUM;
+
+            // If an error is found (svw is non-zero), update the error status.
+            if (err_svs.sv[current_index].svw) {
+                g_reg_file.err_mfr.svw = err_svs.sv[current_index].svw;     // Subsequent violation window
+                g_reg_file.err_mfr.svi = current_index;                     // Update the error index.
+                g_reg_file.err_mfr.svs = 1;                                 // Subsequent Violation Status
+
+                // Get the raw error register value.
+                err_mfr = g_reg_file.err_mfr.raw;
+
+                // Clear the error flag after processing.
+                err_svs.sv[current_index].svw = 0;
+                return err_mfr;  // Return the error register value.
+            }
+        }
+
+        // If no errors are found, return the raw value of the error register.
+        return g_reg_file.err_mfr.raw;
+    }
+
+    // If the offset is within the valid range for entry registers, return the appropriate value.
+    if ((offset >= ENTRY_OFFSET) && (offset < (ENTRY_OFFSET + 0xC + (IOPMP_ENTRY_NUM * ENTRY_REG_STRIDE) + 4))) {
+        // Return 4-byte or 8-byte register value based on num_bytes.
+        return iopmp_entries.regs4[(offset - ENTRY_OFFSET) / num_bytes];
+    }
+
+    // For all other offsets, return the corresponding register value.
+    // If num_bytes is 4, return a 4-byte value, otherwise return an 8-byte value.
+    return g_reg_file.regs4[offset / num_bytes];
+}
+
+/**
+ * @brief Updates the stall status for each RRID based on memory domain stall conditions.
+ *
+ * @param exempt A flag indicating whether the RRID stall status should be exempted.
+ */
+void rrid_stall_update(uint8_t exempt) {
+    uint64_t stall_by_md;
+
+    // Combine the high and low parts of the 'mdstall' register to create a full 64-bit stall mask.
+    stall_by_md = ((uint64_t)g_reg_file.mdstallh.mdh << 31) | g_reg_file.mdstall.md;
+
+    // Iterate through all RRIDs to update the stall status.
+    for (int i = 0; i < IOPMP_RRID_NUM; i++) {
+
+        #if (SRCMD_FMT == 0)
+            uint64_t srcmd_md;
+            // Format 0: Combine srcmd_enh and srcmd_en fields to evaluate stall conditions.
+            // This forms a 64-bit value representing memory domain stall conditions.
+            srcmd_md = ((uint64_t)g_reg_file.srcmd_table[i].srcmd_enh.mdh << 31) | g_reg_file.srcmd_table[i].srcmd_en.md;
+
+            // Update the rrid_stall array based on the combined stall conditions, considering the exempt flag.
+            rrid_stall[i] = exempt ^ ((srcmd_md & stall_by_md) != 0);
+
+        #elif (SRCMD_FMT == 1)
+            // Format 1: Directly use the bit at position `i` in the `stall_by_md` mask for the RRID stall condition.
+            // Because in format 1. RRID i is directly mapped with MD i.
+            rrid_stall[i] = exempt ^ (((stall_by_md >> i) & 1) != 0);
+
+        #elif (SRCMD_FMT == 2)
+            uint64_t srcmd_md;
+            srcmd_md = (1ULL << IOPMP_MD_NUM) - 1;
+            // Update rrid_stall based on the accumulated permissions and the stall conditions.
+            rrid_stall[i] = exempt ^ ((srcmd_md & stall_by_md) != 0);
+        #endif
+    }
+}
+/**
+ * @brief Writes data to a memory-mapped register identified by the specified offset.
+ *
+ * The data type `reg_intf_dw` depends on the configuration in the `config.h` file
+ *  (e.g., `uint32_t` for 4-byte width, `uint64_t` for 8-byte width).
+ *
+ * @param offset The offset of the register to be written.
+ * @param data It contains the data that need to be written.
+ * @param num_bytes The number of bytes to write (either 4 or 8 bytes).
+ *  
+ */
+void write_register(uint16_t offset, reg_intf_dw data, uint8_t num_bytes) {
+
+  // Extract lower and upper 32-bits of data based on bus width
+    uint32_t lwr_data4, upr_data4;
+#if (REG_INTF_BUS_WIDTH == 8)
+    lwr_data4 = data & UINT32_MAX;
+    upr_data4 = (data >> 32) & UINT32_MAX;  // Using 32 bits for upper part
+#else
+    lwr_data4 = data;
+    upr_data4 = data;         // Upper part is same as lower part
+#endif
+
+  // Initialize temporary registers
+    hwcfg0_t         hwcfg0_temp         = { .raw = lwr_data4 };
+    hwcfg2_t         hwcfg2_temp         = { .raw = lwr_data4 };
+    entrylck_t       entrylck_temp       = { .raw = upr_data4 };
+    err_cfg_t        err_cfg_temp        = { .raw = lwr_data4 };
+    entry_addr_t     entry_addr_temp     = { .raw = lwr_data4 };
+    entry_addrh_t    entry_addrh_temp    = { .raw = upr_data4 };
+    entry_cfg_t      entry_cfg_temp      = { .raw = lwr_data4 };
+    entry_user_cfg_t entry_user_cfg_temp = { .raw = upr_data4 };
+
+// Conditional block for error capture
+#if (ERROR_CAPTURE_EN)
+    err_reqinfo_t err_reqinfo_temp = { .raw = upr_data4 };
+#endif
+
+// Conditional block for msi addr
+#if (MSI_EN)
+    err_msiaddr_t    err_msiaddr_temp    = { .raw = lwr_data4 };
+    err_msiaddrh_t   err_msiaddrh_temp   = { .raw = upr_data4 };
+#endif
+
+// Conditional block for SRCMD format
+#if (SRCMD_FMT != 1)
+    mdlck_t  mdlck_temp  = { .raw = lwr_data4 };
+    mdlckh_t mdlckh_temp = { .raw = upr_data4 };
+#endif
+
+// MDCFG format check
+#if (MDCFG_FMT == 0)
+    mdcfglck_t mdcfglck_temp = { .raw = lwr_data4 };
+    mdcfg_t    mdcfg_temp    = { .raw = data };
+#endif
+
+// SRCMD format handling
+#if (SRCMD_FMT == 0)
+    srcmd_en_t  srcmd_en_temp  = { .raw = lwr_data4 & ((IOPMP_MD_NUM >= 32) ? UINT32_MAX : (1ULL << (IOPMP_MD_NUM + 1)) - 1) };
+    srcmd_enh_t srcmd_enh_temp = { .raw = (IOPMP_MD_NUM < 32) ? 0 : upr_data4 & ((1ULL << (IOPMP_MD_NUM - 32)) - 1) };
+    srcmd_r_t   srcmd_r_temp   = { .raw = lwr_data4 & ((IOPMP_MD_NUM >= 32) ? UINT32_MAX : (1ULL << (IOPMP_MD_NUM + 1)) - 1) };
+    srcmd_rh_t  srcmd_rh_temp  = { .raw = (IOPMP_MD_NUM < 32) ? 0 : upr_data4 & ((1ULL << (IOPMP_MD_NUM - 32)) - 1) };
+    srcmd_w_t   srcmd_w_temp   = { .raw = lwr_data4 & ((IOPMP_MD_NUM >= 32) ? UINT32_MAX : (1ULL << (IOPMP_MD_NUM + 1)) - 1) };
+    srcmd_wh_t  srcmd_wh_temp  = { .raw = (IOPMP_MD_NUM < 32) ? 0 : upr_data4 & ((1ULL << (IOPMP_MD_NUM - 32)) - 1) };
+#elif (SRCMD_FMT == 2)
+    srcmd_perm_t  srcmd_perm_temp  = { .raw = lwr_data4 };
+    srcmd_permh_t srcmd_permh_temp = { .raw = upr_data4 };
+#endif
+
+// IOPMP Stall configuration
+#if (IOPMP_STALL_EN)
+    mdstall_t  mdstall_temp  = { .raw = lwr_data4 & ((IOPMP_MD_NUM >= 32) ? UINT32_MAX : (1ULL << (IOPMP_MD_NUM + 1)) - 1) };
+    mdstallh_t mdstallh_temp = { .raw = (IOPMP_MD_NUM < 32) ? 0 : upr_data4 & ((1ULL << (IOPMP_MD_NUM - 32)) - 1) };
+    rridscp_t  rridscp_temp  = { .raw = lwr_data4 };
+    rridscp_temp.op     = (lwr_data4 >> 30) & MASK_BIT_POS(2);
+    mdstall_temp.md     = (lwr_data4 >> 1) & ((IOPMP_MD_NUM >= 32) ? UINT32_MAX : (1ULL << IOPMP_MD_NUM) - 1);
+    mdstall_temp.exempt = GET_BIT(lwr_data4, 0);
+#endif
+
+// IOPMP MFR configuration
+#if (IOPMP_MFR_EN == 1)
+    err_mfr_t err_mfr_temp = { .raw = upr_data4 };
+#endif
+
+  if (!is_access_valid(offset, num_bytes)) return;
+
+  switch (offset) {
+    case VERSION_OFFSET:
+      // This register is read only
+      return;
+
+    case IMPLEMENTATION_OFFSET:
+      // This register is read only
+      return;
+
+    case HWCFG0_OFFSET:
+        g_reg_file.hwcfg0.prient_prog      &= ~hwcfg0_temp.prient_prog;
+        g_reg_file.hwcfg0.rrid_transl_prog &= ~hwcfg0_temp.rrid_transl_prog;
+        g_reg_file.hwcfg0.enable           |= hwcfg0_temp.enable;
+        #if (MDCFG_FMT == 2)
+            g_reg_file.hwcfg0.md_entry_num = hwcfg0_temp.md_entry_num;
+        #endif
+        break;
+
+    case HWCFG1_OFFSET:
+        // This register is read only
+        return;
+
+    case HWCFG2_OFFSET:
+        if (g_reg_file.hwcfg0.prient_prog) {
+            g_reg_file.hwcfg2.prio_entry  = hwcfg2_temp.prio_entry;
+        }
+        if (g_reg_file.hwcfg0.rrid_transl_en & g_reg_file.hwcfg0.rrid_transl_prog) {
+            g_reg_file.hwcfg2.rrid_transl = hwcfg2_temp.rrid_transl;
+        }
+        break;
+
+    case ENTRYOFFSET_OFFSET:
+        // This register is read only
+        return;
+
+#if (IOPMP_STALL_EN)
+    case MDSTALL_OFFSET:
+        g_reg_file.mdstall.exempt = mdstall_temp.exempt;
+        g_reg_file.mdstall.md     = mdstall_temp.md;
+        rrid_stall_update (g_reg_file.mdstall.exempt);
+        g_reg_file.mdstall.is_stalled = (g_reg_file.mdstall.raw != 0) ? 1 : 0;
+        if (num_bytes == 4) break;
+
+    case MDSTALLH_OFFSET:
+        g_reg_file.mdstallh.mdh = mdstallh_temp.mdh;
+        break;
+
+    case RRISCP_OFFSET:
+        g_reg_file.rridscp.rsv  = 0;
+        g_reg_file.rridscp.op   = rridscp_temp.op;
+        if (rridscp_temp.rrid < IOPMP_RRID_NUM) {
+            g_reg_file.rridscp.rrid = rridscp_temp.rrid;
+        }
+        else if (g_reg_file.rridscp.op == 0) {
+            g_reg_file.rridscp.stat = 3;
+            break;
+        }
+
+        if (g_reg_file.rridscp.op == 0) {
+            g_reg_file.rridscp.stat = 2 - rrid_stall[g_reg_file.rridscp.rrid];
+        }
+        break;
+#endif
+
+#if (SRCMD_FMT != 1) & (IMP_MDLCK)
+    case MDLCK_OFFSET:
+        if (!g_reg_file.mdlck.l) {
+            g_reg_file.mdlck.l   |= mdlck_temp.l;
+            g_reg_file.mdlck.md   = mdlck_temp.md;
+        }
+        if (num_bytes) break;
+
+    case MDLCKH_OFFSET:
+        if (!g_reg_file.mdlck.l) {
+            g_reg_file.mdlckh.mdh = mdlckh_temp.mdh;
+        }
+        break;
+#endif
+
+#if (MDCFG_FMT == 0)
+    case MDCFGLCK_OFFSET:
+        if (!g_reg_file.mdcfglck.l) {
+            g_reg_file.mdcfglck.l   |= mdcfglck_temp.l;
+            if (mdcfglck_temp.f > g_reg_file.mdcfglck.f) {
+                g_reg_file.mdcfglck.f   = mdcfglck_temp.f;
+            }
+            g_reg_file.mdcfglck.rsv = 0;
+        }
+        break;
+#endif
+
+    case ENTRYLCK_OFFSET:
+        if (!g_reg_file.entrylck.l) {
+            g_reg_file.entrylck.l   |= entrylck_temp.l;
+            if (entrylck_temp.f > g_reg_file.entrylck.f) {
+            g_reg_file.entrylck.f   = entrylck_temp.f;
+            }
+            g_reg_file.entrylck.rsv = 0;
+        }
+        g_reg_file.entrylck.rsv = 0;
+        break;
+
+    case ERR_OFFSET:
+        if (!g_reg_file.err_cfg.l) {
+            g_reg_file.err_cfg.l       |= err_cfg_temp.l;
+            g_reg_file.err_cfg.ie       = err_cfg_temp.ie;
+            g_reg_file.err_cfg.rs       = err_cfg_temp.rs;
+            g_reg_file.err_cfg.msi_en   = err_cfg_temp.msi_en & MSI_EN;
+            g_reg_file.err_cfg.msidata  = err_cfg_temp.msidata;
+            g_reg_file.err_cfg.rsv1     = 0;
+            g_reg_file.err_cfg.rsv2     = 0;
+        }
+        break;
+
+#if (ERROR_CAPTURE_EN)
+    case ERR_REQINFO_OFFSET:
+        g_reg_file.err_reqinfo.v    &= ~err_reqinfo_temp.v;
+        g_reg_file.err_reqinfo.rsv1 = 0;
+        g_reg_file.err_reqinfo.rsv2 = 0;
+        break;
+
+    case ERR_REQADDR_OFFSET:
+        return;
+
+    case ERR_REQADDRH_OFFSET:
+        return;
+#endif
+
+#if (IMP_ERROR_REQID)
+    case ERR_REQID_OFFSET:
+        return;
+#endif
+
+    case ERR_MFR_OFFSET:
+        g_reg_file.err_mfr.svi = err_mfr_temp.svi;
+        break;
+
+#if (MSI_EN)
+    case ERR_MSIADDR_OFFSET:
+        g_reg_file.err_msiaddr.raw = err_msiaddr_temp.raw;
+        break;
+
+    case ERR_MSIADDRH_OFFSET:
+        #if (IOPMP_ADDRH_EN)
+            g_reg_file.err_msiaddrh.raw = err_msiaddrh_temp.raw;
+        #endif
+        break;
+#endif
+
+    case ERR_USER0_OFFSET:
+    case ERR_USER1_OFFSET:
+    case ERR_USER2_OFFSET:
+    case ERR_USER3_OFFSET:
+    case ERR_USER4_OFFSET:
+    case ERR_USER5_OFFSET:
+    case ERR_USER6_OFFSET:
+    case ERR_USER7_OFFSET:
+        break;
+
+    default:
+        break;
+  }
+
+#if (MDCFG_FMT == 0)
+    if ((((offset-MDCFG_TABLE_BASE_OFFSET)/4) >= g_reg_file.mdcfglck.f) & IS_IN_RANGE(offset, MDCFG_TABLE_BASE_OFFSET, (MDCFG_TABLE_BASE_OFFSET + (IOPMP_MD_NUM*4)))){
+        if (mdcfg_temp.t < IOPMP_ENTRY_NUM) {
+            g_reg_file.mdcfg[(offset-MDCFG_TABLE_BASE_OFFSET)/4].t   = mdcfg_temp.t;
+        }
+        g_reg_file.mdcfg[(offset-MDCFG_TABLE_BASE_OFFSET)/4].rsv = 0;
+    }
+#endif
+
+// Code block for handling SRCMD table accesses based on format type
+#if (SRCMD_FMT != 1)
+    int srcmd_tlb_access;
+    int is_srcmd_locked = 0;  // Initialize as unlocked
+
+    // Pre-compute access range and lock status based on format type
+    #if (SRCMD_FMT == 0)
+        srcmd_tlb_access = IS_IN_RANGE(offset, SRCMD_TABLE_BASE_OFFSET, SRCMD_TABLE_BASE_OFFSET + (IOPMP_RRID_NUM * SRCMD_REG_STRIDE) + 28);
+        is_srcmd_locked = g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_en.l;
+
+    #elif (SRCMD_FMT == 2)
+        srcmd_tlb_access = IS_IN_RANGE(offset, SRCMD_TABLE_BASE_OFFSET, SRCMD_TABLE_BASE_OFFSET + (IOPMP_MD_NUM * SRCMD_REG_STRIDE) + 8);
+        int table_index = SRCMD_TABLE_INDEX(offset);
+
+        if (table_index < 31) {
+            is_srcmd_locked = (g_reg_file.mdlck.md >> table_index) & 1;
+        } else {
+            is_srcmd_locked = (g_reg_file.mdlckh.mdh >> (table_index - 31)) & 1;
+        }
+    #endif
+
+    // Proceed only if within access range and not locked
+    if (srcmd_tlb_access && !is_srcmd_locked) {
+        uint32_t srcmd_reg = SRCMD_REG_INDEX(offset);
+
+        switch (srcmd_reg) {
+            #if (SRCMD_FMT == 0)
+                // SRCMD_EN Register
+                case 0:
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_en.l |= srcmd_en_temp.l;
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_en.md =
+                        (srcmd_en_temp.md & ~g_reg_file.mdlck.md) |
+                        (g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_en.md & g_reg_file.mdlck.md);
+                    if (num_bytes == 4) break;
+
+                // SRCMD_ENH Register
+                case 1:
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_enh.mdh =
+                        ((srcmd_enh_temp.mdh & ~g_reg_file.mdlckh.mdh) |
+                         (g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_enh.mdh & g_reg_file.mdlckh.mdh));
+                    break;
+
+                // SRCMD_R Register
+                case 2:
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_r.rsv = 0;
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_r.md =
+                        (srcmd_r_temp.md & ~g_reg_file.mdlck.md) |
+                        (g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_r.md & g_reg_file.mdlck.md);
+                    if (num_bytes == 4) break;
+
+                // SRCMD_RH Register
+                case 3:
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_rh.mdh =
+                        ((srcmd_rh_temp.mdh & ~g_reg_file.mdlckh.mdh) |
+                         (g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_rh.mdh & g_reg_file.mdlckh.mdh));
+                    break;
+
+                // SRCMD_W Register
+                case 4:
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_w.rsv = 0;
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_w.md =
+                        (srcmd_w_temp.md & ~g_reg_file.mdlck.md) |
+                        (g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_w.md & g_reg_file.mdlck.md);
+                    if (num_bytes == 4) break;
+
+                // SRCMD_WH Register
+                case 5:
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_wh.mdh =
+                        ((srcmd_wh_temp.mdh & ~g_reg_file.mdlckh.mdh) |
+                         (g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_wh.mdh & g_reg_file.mdlckh.mdh));
+                    break;
+
+            #elif (SRCMD_FMT == 2)
+                // SRCMD_PERM Register
+                case 0:
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_perm.perm = srcmd_perm_temp.perm;
+                    if (num_bytes == 4) break;
+
+                // SRCMD_PERMH Register
+                case 1:
+                    g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_permh.permh = srcmd_permh_temp.permh;
+                    break;
+            #endif
+
+            default:
+                break;
+        }
+    }
+#endif
+
+    if (IS_IN_RANGE(offset, ENTRY_TABLE_BASE_OFFSET, ENTRY_TABLE_BASE_OFFSET + (IOPMP_ENTRY_NUM * ENTRY_REG_STRIDE) + 12)) {
+        uint32_t entry_reg = ENTRY_REG_INDEX(offset);
+        if (ENTRY_TABLE_INDEX(offset) >= g_reg_file.entrylck.f) {
+            switch (entry_reg)
+            {
+                // Entry Addr Register
+                case 0:
+                    iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_addr.addr = entry_addr_temp.addr;
+                    if ((num_bytes == 4) || !IOPMP_ADDRH_EN) break;
+
+                // Entry Addrh Register
+                case 1:
+                    #if (IOPMP_ADDRH_EN)
+                        iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_addrh.addrh = entry_addrh_temp.addrh;
+                    #endif
+                    break;
+
+                // Entry Cfg Register
+                case 2:
+                    iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.r = entry_cfg_temp.r;
+                    iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.w = entry_cfg_temp.w & entry_cfg_temp.r;
+                    iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.x = entry_cfg_temp.x;
+                    if (entry_cfg_temp.a == IOPMP_TOR) {
+                        // ENTRY_CFG.A is WARL, check for TOR Enable before, writing.
+                        if (g_reg_file.hwcfg0.tor_en) {
+                            iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.a = entry_cfg_temp.a;
+                        }
+                    }
+                    else {
+                        iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.a = entry_cfg_temp.a;
+                    }
+
+                    // Interrupt suppression bits are writeable, only if interrupt suppression is supported
+                    if (g_reg_file.hwcfg0.peis){
+                        iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.sire = entry_cfg_temp.sire;
+                        iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.siwe = entry_cfg_temp.siwe;
+                        iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.sixe = entry_cfg_temp.sixe;
+                    }
+
+                    // Error suppression bits are writeable, only if error suppression is supported
+                    if (g_reg_file.hwcfg0.pees) {
+                        iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.sere = entry_cfg_temp.sere;
+                        iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.sewe = entry_cfg_temp.sewe;
+                        iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.sexe = entry_cfg_temp.sexe;
+                    }
+                    iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_cfg.rsv = 0;
+                    break;
+
+                case 3:
+                    iopmp_entries.entry_table[ENTRY_TABLE_INDEX(offset)].entry_user_cfg.im = entry_user_cfg_temp.im;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/iopmp_ref_model/src/iopmp_rule_analyzer.c
+++ b/iopmp_ref_model/src/iopmp_rule_analyzer.c
@@ -1,0 +1,217 @@
+/***************************************************************************
+// Author: Yazan Hussnain (yazan.hussain@10xengineers.ai)
+// Date: October 21, 2024
+// Description:
+// This file implements the IOPMP (I/O Physical Memory Protection)
+// Permission Check for RISC-V systems. It contains functions to compute
+// and validate address ranges, match transaction requests against IOPMP
+// entries, and enforce access permissions (Read, Write, Execute) based
+// on the IOPMP configuration and hardware restrictions. The IOPMP
+// protects memory regions for peripheral accesses, ensuring only
+// authorized transactions occur within specified address ranges and
+// permissions.
+//
+// The main functions in this file include:
+// - iopmpAddrRange: Computes address ranges for IOPMP entries based on
+//   entry configurations, supporting modes such as NA4, TOR, and NAPOT.
+// - iopmpMatchAddr: Matches transaction request addresses against an
+//   IOPMP entry range, with priority handling.
+// - iopmpCheckPerms: Verifies permissions against the IOPMP entry
+//   configuration and Requestor Role ID (RRID) to allow or deny access.
+// - iopmpRuleAnalyzer: Analyzes IOPMP rules to determine if a transaction
+//   matches an entry and has the required permissions, considering
+//   priority and configuration-specific conditions.
+//
+***************************************************************************/
+
+#include "iopmp.h"
+
+/**
+  * @brief Computes the address range based on the IOPMP entry configuration.
+  *
+  * @param startAddr Pointer to store the start address of the range
+  * @param endAddr Pointer to store the end address of the range
+  * @param prev_iopmpaddr Previous IOPMP address (used in TOR mode)
+  * @param iopmpaddr Current IOPMP address
+  * @param iopmpcfg IOPMP entry configuration
+  * @return 0 on success, 1 if the IOPMP entry is disabled
+ **/
+int iopmpAddrRange(uint64_t *startAddr, uint64_t *endAddr, uint64_t prev_iopmpaddr, uint64_t iopmpaddr, entry_cfg_t iopmpcfg) {
+    uint64_t napot_mask;
+    // Check if IOPMP entry is OFF
+    if (iopmpcfg.a == IOPMP_OFF) { return 1; }
+
+    switch (iopmpcfg.a) {
+        case IOPMP_NA4:  // Address range covers a single 4-byte address
+            *startAddr = iopmpaddr;
+            *endAddr   = iopmpaddr + 1;
+            break;
+
+        case IOPMP_TOR:  // Address range specified by top-of-range mode
+            *startAddr = prev_iopmpaddr;
+            *endAddr   = iopmpaddr;
+            break;
+
+        default:  // Assume NAPOT (Naturally Aligned Power-of-Two) mode
+            napot_mask = iopmpaddr ^ (iopmpaddr + 1);
+            *startAddr = iopmpaddr & ~napot_mask;
+            *endAddr   = *startAddr + napot_mask + 1;
+            break;
+    }
+
+    return 0;
+}
+
+/**
+  * @brief Matches transaction request address against IOPMP entry range.
+  *
+  * @param trans_req Transaction request containing address, size, and length
+  * @param lo Lower bound of the IOPMP range
+  * @param hi Upper bound of the IOPMP range
+  * @param is_priority Flag indicating if the entry has priority
+  * @return 0 for a full match, ENTRY_NOTMATCH for no match, or PARTIAL_HIT_ON_PRIORITY for a partial match with priority
+ **/
+int iopmpMatchAddr(iopmp_trans_req_t trans_req, uint64_t lo, uint64_t hi, int is_priority) {
+    // Validate range
+    if (hi < lo) { return ENTRY_NOTMATCH; }  // Invalid range, no match
+
+    // Compute the end address of the transaction
+    uint64_t trans_end = trans_req.addr + ((int)pow(2, trans_req.size) * (trans_req.length + 1));
+
+    // Check if transaction falls outside the IOPMP entry range
+    if (trans_end <= lo || trans_req.addr >= hi) { return ENTRY_NOTMATCH; } // No match, transaction outside range
+
+    // Determine if there's a full match
+    if (trans_req.addr >= lo && trans_end <= hi) { return 0; } // Full Match
+
+    // Check for partial match if entry has priority
+    return is_priority ? PARTIAL_HIT_ON_PRIORITY : ENTRY_NOTMATCH;
+}
+
+/**
+  * @brief Checks IOPMP permissions based on request and configuration.
+  *
+  * @param rrid Requestor Role ID
+  * @param req_perm Requested permission type (Read, Write, Execute)
+  * @param iopmpcfg IOPMP configuration for the entry
+  * @param md Respective Memory Domain
+  * @return ENTRY_MATCH if permission is granted, specific ILLEGAL_* code if denied
+ **/
+iopmpMatchStatus_t iopmpCheckPerms(uint16_t rrid, perm_type_e req_perm, entry_cfg_t iopmpcfg, uint8_t md) {
+
+    #if (SRCMD_FMT == 0)
+        uint64_t srcmd_r, srcmd_w;
+        uint8_t  srcmd_r_bit, srcmd_w_bit;
+        srcmd_r     = CONCAT32(g_reg_file.srcmd_table[rrid].srcmd_rh.raw, g_reg_file.srcmd_table[rrid].srcmd_r.raw);
+        srcmd_w     = CONCAT32(g_reg_file.srcmd_table[rrid].srcmd_wh.raw, g_reg_file.srcmd_table[rrid].srcmd_w.raw);
+        srcmd_r_bit = GET_BIT(srcmd_r, (md + 1));
+        srcmd_w_bit = GET_BIT(srcmd_w, (md + 1));
+    #elif (SRCMD_FMT == 2)
+        uint64_t srcmd_perm;
+        uint8_t  srcmd_perm_r, srcmd_perm_w;
+        srcmd_perm   = CONCAT32(g_reg_file.srcmd_table[md].srcmd_permh.raw, g_reg_file.srcmd_table[md].srcmd_perm.raw);
+        srcmd_perm_r = GET_BIT(srcmd_perm, (rrid * 2));
+        srcmd_perm_w = GET_BIT(srcmd_perm, ((rrid * 2) + 1));
+    #endif
+
+    // Extract hardware configuration flags
+#if (SRCMD_FMT == 0)
+    bool sps_en = g_reg_file.hwcfg0.sps_en;  // Software privilege separation enable
+#endif
+    bool chk_x  = g_reg_file.hwcfg0.chk_x;    // Execute permission check enable
+
+    // Common permission checks
+    bool read_allowed    = false;
+    bool write_allowed   = false;
+    bool execute_allowed = false;
+
+    #if (SRCMD_FMT == 0)
+        read_allowed    = sps_en ? (iopmpcfg.r & srcmd_r_bit) : iopmpcfg.r;
+        write_allowed   = (sps_en ? (iopmpcfg.w & srcmd_w_bit & iopmpcfg.r & srcmd_r_bit) : (iopmpcfg.w & iopmpcfg.r));
+        execute_allowed = (sps_en ? (iopmpcfg.x & srcmd_r_bit) : iopmpcfg.x);
+    #elif (SRCMD_FMT == 1)
+        read_allowed    = iopmpcfg.r;
+        write_allowed   = (iopmpcfg.w & iopmpcfg.r);
+        execute_allowed = iopmpcfg.x;
+    #elif (SRCMD_FMT == 2)
+        read_allowed    = iopmpcfg.r || srcmd_perm_r;
+        write_allowed   = ((iopmpcfg.w || srcmd_perm_w) & (iopmpcfg.r || srcmd_perm_r));
+        execute_allowed = (iopmpcfg.x || srcmd_perm_r);
+    #endif
+
+    // Handle requested permission type
+    switch (req_perm) {
+        case READ_ACCESS:
+            if (!read_allowed) {
+                intrpt_suppress = iopmpcfg.sire;
+                error_suppress  = iopmpcfg.sere | g_reg_file.err_cfg.rs;
+            }
+            return read_allowed ? ENTRY_MATCH : ILLEGAL_READ_ACCESS;
+
+        case WRITE_ACCESS:
+            if (!write_allowed) {
+                intrpt_suppress = iopmpcfg.siwe;
+                error_suppress  = iopmpcfg.sewe | g_reg_file.err_cfg.rs;
+            }
+            return write_allowed ? ENTRY_MATCH : ILLEGAL_WRITE_ACCESS;
+
+        case INSTR_FETCH:
+            if (chk_x) {
+                if (!execute_allowed) {
+                    intrpt_suppress = iopmpcfg.sixe;
+                    error_suppress  = iopmpcfg.sexe | g_reg_file.err_cfg.rs;
+                }
+                return execute_allowed ? ENTRY_MATCH : ILLEGAL_INSTR_FETCH;
+            } else if (read_allowed) {
+                return ENTRY_MATCH;  // Grant Execute permission via Read fallback
+            }
+            intrpt_suppress = iopmpcfg.sixe;
+            error_suppress  = iopmpcfg.sexe | g_reg_file.err_cfg.rs;
+            return ILLEGAL_INSTR_FETCH;
+
+        default:
+            return ILLEGAL_READ_ACCESS;  // Default case for invalid permission request
+    }
+}
+
+/**
+  * @brief Matches the transaction request to an IOPMP entry, handling priority and permissions.
+  *
+  * @param trans_req Transaction request containing address, permissions, etc.
+  * @param prev_iopmpaddr Previous IOPMP address (used in TOR mode)
+  * @param iopmpaddr Current IOPMP address
+  * @param iopmpcfg IOPMP entry configuration
+  * @param md Respective Memory Domain
+  * @param is_priority Flag indicating if the entry has priority
+  * @return iopmpMatchStatus_t Status of the match:
+  *         - ENTRY_MATCH: Full match, access granted.
+  *         - ENTRY_NOTMATCH: No match or access denied.
+  *         - PARTIAL_HIT_ON_PRIORITY: Partial match found with priority.
+  *         - ILLEGAL_* status: Access denied based on permission type (e.g., read/write/execute).
+ **/
+iopmpMatchStatus_t iopmpRuleAnalyzer(iopmp_trans_req_t trans_req, uint64_t prev_iopmpaddr, uint64_t iopmpaddr, entry_cfg_t iopmpcfg, uint8_t md, int is_priority) {
+    iopmpMatchStatus_t match_status = ENTRY_MATCH;  // Default to full match
+    uint64_t start_addr, end_addr;
+    bool no_w  = g_reg_file.hwcfg0.no_w;      // Write restriction
+    bool no_x  = g_reg_file.hwcfg0.no_x;      // Execute restriction
+    bool chk_x = g_reg_file.hwcfg0.chk_x;    // Execute permission check enable
+    if ((no_w && (trans_req.perm == WRITE_ACCESS)) || (no_x && (trans_req.perm == INSTR_FETCH) && chk_x)) { return ENTRY_NOTMATCH; }
+
+    // Set up the address range; if range setup fails, return not matched
+    if (iopmpAddrRange(&start_addr, &end_addr, prev_iopmpaddr, iopmpaddr, iopmpcfg)) { return ENTRY_NOTMATCH; }
+
+    // Match transaction address to the IOPMP address range
+    // Multiply the addresses with 4 is equivalent to (Address << 2)
+    int addr_match_status = iopmpMatchAddr(trans_req, (start_addr * 4), (end_addr * 4), is_priority);
+    if (addr_match_status == PARTIAL_HIT_ON_PRIORITY) {
+        error_suppress = g_reg_file.err_cfg.rs;
+        return PARTIAL_HIT_ON_PRIORITY;  // Priority entry partial match
+    }
+    if (addr_match_status) { return ENTRY_NOTMATCH; } // No match found
+
+    // Check access permissions
+    match_status = iopmpCheckPerms(trans_req.rrid, trans_req.perm, iopmpcfg, md);
+
+    // If all checks pass, return full match status
+    return match_status;
+}

--- a/iopmp_ref_model/src/iopmp_rule_analyzer.c
+++ b/iopmp_ref_model/src/iopmp_rule_analyzer.c
@@ -1,5 +1,6 @@
 /***************************************************************************
 // Author: Yazan Hussnain (yazan.hussain@10xengineers.ai)
+//         Gull Ahmed (gull.ahmed@10xengineers.ai)
 // Date: October 21, 2024
 // Description:
 // This file implements the IOPMP (I/O Physical Memory Protection)
@@ -209,8 +210,12 @@ iopmpMatchStatus_t iopmpRuleAnalyzer(iopmp_trans_req_t trans_req, uint64_t prev_
     }
     if (addr_match_status) { return ENTRY_NOTMATCH; } // No match found
 
+    #if (SRC_ENFORCEMENT_EN)
+        match_status = iopmpCheckPerms(0, trans_req.perm, iopmpcfg, md);
+    #else
     // Check access permissions
-    match_status = iopmpCheckPerms(trans_req.rrid, trans_req.perm, iopmpcfg, md);
+        match_status = iopmpCheckPerms(trans_req.rrid, trans_req.perm, iopmpcfg, md);
+    #endif
 
     // If all checks pass, return full match status
     return match_status;

--- a/iopmp_ref_model/src/iopmp_validate.c
+++ b/iopmp_ref_model/src/iopmp_validate.c
@@ -1,0 +1,146 @@
+/***************************************************************************
+// Author: Gull Ahmed (gull.ahmed@10xengineers.ai)
+//         Yazan Hussnain (yazan.hussain@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains the iopmp_validate_access function that
+// Processes the IOPMP transaction request, traversing the SRCMD and MDCFG tables
+// and entry array to match address and permissions and return the response
+// structure based upon the transaction status.
+***************************************************************************/
+
+#include "iopmp.h"
+
+iopmp_regs_t    g_reg_file;
+iopmp_entries_t iopmp_entries;
+err_mfrs_t      err_svs;
+int             intrpt_suppress;
+int             error_suppress;
+
+/**
+  * @brief Processes the IOPMP transaction request, traversing the SRCMD and MDCFG tables
+  *        and entry array to match address and permissions.
+  *
+  * @param trans_req The transaction request with required address, permissions, etc.
+  * @param intrpt Pointer to the interrupt flag.
+  * @return iopmp_trans_rsp_t Response structure with transaction status.
+ **/
+iopmp_trans_rsp_t iopmp_validate_access(iopmp_trans_req_t trans_req, uint8_t *intrpt) {
+    iopmp_trans_rsp_t iopmp_trans_rsp = {
+        .rrid         = trans_req.rrid,
+    #if (IOPMP_RRID_TRANSL_EN)
+        .rrid_transl  = g_reg_file.hwcfg2.rrid_transl,
+    #endif
+        .rrid_stalled = 0,
+        .status       = IOPMP_ERROR
+    };
+    intrpt_suppress = 0;
+    error_suppress  = 0;
+    int lwr_entry, upr_entry;
+
+    #if (SRCMD_FMT == 0)
+        srcmd_en_t  srcmd_en;
+        srcmd_enh_t srcmd_enh;
+    #endif
+
+    iopmpMatchStatus_t iopmpMatchStatus;
+    #if (ERROR_CAPTURE_EN)
+        iopmpMatchStatus_t nonPrioRuleStatus;
+        int nontPrioRuleNum = 0;
+        int nonPrioErrorSup = 0;
+        nonPrioRuleStatus = NOT_HIT_ANY_RULE;
+    #endif
+
+    // Check for valid RRID; if invalid, capture error and return
+    if (trans_req.rrid >= IOPMP_RRID_NUM) {
+        // Initially, checkf for global error suppression
+        error_suppress = g_reg_file.err_cfg.rs;
+        #if (ERROR_CAPTURE_EN)
+            errorCapture(trans_req.perm, UNKNOWN_RRID, trans_req.rrid, 0, trans_req.addr, intrpt);
+        #endif
+        // In case of error suppression, success response is returned, with user defined value on initiator port
+        // NOTE: You can change the `user` value
+        if (error_suppress) { iopmp_trans_rsp.status = IOPMP_SUCCESS; iopmp_trans_rsp.user = USER; }
+        return iopmp_trans_rsp;
+    }
+
+    if (g_reg_file.mdstall.is_stalled) {
+        if (rrid_stall[trans_req.rrid]) {
+            iopmp_trans_rsp.rrid_stalled = 1;
+            return iopmp_trans_rsp;
+        }
+    }
+
+    // Read SRCMD table based on `rrid`
+    #if (SRCMD_FMT == 0)
+        srcmd_en  = g_reg_file.srcmd_table[trans_req.rrid].srcmd_en;
+        srcmd_enh = g_reg_file.srcmd_table[trans_req.rrid].srcmd_enh;
+    #endif
+
+    // Determine MDCFG table range for entries
+    #if (SRCMD_FMT != 1)
+        int start_md_num = 0;
+        int end_md_num   = IOPMP_MD_NUM;
+    #else
+        int start_md_num = trans_req.rrid;
+        int end_md_num   = trans_req.rrid + 1;
+    #endif
+
+    // Traverse each MD entry and perform address/permission checks
+    for (int cur_md = start_md_num; cur_md < end_md_num; ++cur_md) {
+        #if (SRCMD_FMT == 0)
+            if (!IS_MD_ASSOCIATED(cur_md, srcmd_en.md, srcmd_enh.mdh)) continue;
+        #endif
+
+        #if (MDCFG_FMT == 0)
+            lwr_entry = (cur_md == 0) ? 0 : g_reg_file.mdcfg[cur_md - 1].t;
+            upr_entry = g_reg_file.mdcfg[cur_md].t;
+        #else
+            lwr_entry = cur_md * (g_reg_file.hwcfg0.md_entry_num + 1);
+            upr_entry = ((cur_md + 1) * (g_reg_file.hwcfg0.md_entry_num + 1));
+        #endif
+
+        for (int cur_entry = lwr_entry; cur_entry <= upr_entry; cur_entry++) {
+            uint64_t prev_addr     = CONCAT32(iopmp_entries.entry_table[cur_entry - 1].entry_addrh.addrh, iopmp_entries.entry_table[cur_entry - 1].entry_addr.addr);
+            uint64_t curr_addr     = CONCAT32(iopmp_entries.entry_table[cur_entry].entry_addrh.addrh, iopmp_entries.entry_table[cur_entry].entry_addr.addr);     
+            entry_cfg_t entry_cfg  = iopmp_entries.entry_table[cur_entry].entry_cfg;
+            bool is_priority_entry = (cur_entry < g_reg_file.hwcfg2.prio_entry);
+
+            // Analyze entry for match
+            iopmpMatchStatus = iopmpRuleAnalyzer(trans_req, prev_addr, curr_addr, entry_cfg, cur_md, is_priority_entry);
+
+            if (iopmpMatchStatus == ENTRY_MATCH) {
+                iopmp_trans_rsp.status = IOPMP_SUCCESS;
+                return iopmp_trans_rsp;  // Return on successful match
+            } else if (iopmpMatchStatus != ENTRY_NOTMATCH) {
+                if (!is_priority_entry) {
+                    #if (ERROR_CAPTURE_EN)
+                        nonPrioRuleStatus = iopmpMatchStatus;
+                        nonPrioErrorSup   = error_suppress;
+                        nontPrioRuleNum   = cur_entry;
+                    #endif
+                    continue;
+                }
+                #if (ERROR_CAPTURE_EN)
+                    errorCapture(trans_req.perm, iopmpMatchStatus, trans_req.rrid, cur_entry, trans_req.addr, intrpt);
+                #endif
+                // In case of error suppression, success response is returned, with user defined value on initiator port
+                // NOTE: You can change the `user` value
+                if (error_suppress) { iopmp_trans_rsp.status = IOPMP_SUCCESS; iopmp_trans_rsp.user = USER; }
+                return iopmp_trans_rsp;  // Error found, capture and return response
+            }
+        }
+    }
+
+    // If No rule hits, enable error suppression based on global error suppression bit
+    if (nonPrioRuleStatus == NOT_HIT_ANY_RULE) { error_suppress = g_reg_file.err_cfg.rs; }
+    else { error_suppress = nonPrioErrorSup; }
+
+    #if (ERROR_CAPTURE_EN)
+        errorCapture(trans_req.perm, nonPrioRuleStatus, trans_req.rrid, nontPrioRuleNum, trans_req.addr, intrpt);
+    #endif
+    // Return response with default status if no match/error occurs
+    // In case of error suppression, success response is returned, with user defined value on initiator port
+    // NOTE: You can change the `user` value
+    if (error_suppress) { iopmp_trans_rsp.status = IOPMP_SUCCESS; iopmp_trans_rsp.user = USER; }
+    return iopmp_trans_rsp;
+}

--- a/iopmp_ref_model/verif/test_utils.c
+++ b/iopmp_ref_model/verif/test_utils.c
@@ -1,0 +1,140 @@
+/***************************************************************************
+// Author: Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the functions that could be used
+// while testing any IOPMP Model.
+***************************************************************************/
+#include "test_utils.h"
+#include "config.h"
+#include "iopmp.h"
+
+/**
+  * @brief Allocates memory of the specified size in gigabytes.
+  *
+  * @param mem_gb - The size of the memory to allocate in gigabytes.
+  * @return 0 if the memory allocation was successful, -1 otherwise.
+ **/
+int create_memory(uint8_t mem_gb) {
+    // Calculate the total memory size in bytes
+    size_t total_size = (size_t)mem_gb * 1024UL * 1024UL * 1024UL;
+
+    // Allocate memory and check for allocation failure
+    memory = malloc(total_size);
+    if (memory == NULL) {
+        return -1; // Memory allocation failed
+    }
+
+    return 0; // Memory allocation successful
+}
+
+/**
+  * @brief Read data from a specific memory address.
+  *
+  * @param addr - The memory address from where the data should be read.
+  * @param size - The size of the data in bytes.
+  * @param data - Pointer to the data for read.
+  * @return 0 if the read was successful, BUS_ERROR if the address corresponds to a bus error.
+ **/
+uint8_t read_memory(uint64_t addr, uint8_t size, char *data) {
+    // Validate address against bus_error
+    if (addr == bus_error) { return BUS_ERROR; }
+
+    // Perform memory read
+    memcpy(data, &memory[addr], size);
+    return 0; // Read successfult
+}
+
+/**
+  * @brief Writes data to a specific memory address.
+  *
+  * @param data - Pointer to the data to write.
+  * @param addr - The memory address where the data should be written.
+  * @param size - The size of the data in bytes.
+  * @return 0 if the write was successful, BUS_ERROR if the address corresponds to a bus error.
+ **/
+uint8_t write_memory(char *data, uint64_t addr, uint32_t size) {
+    // Validate address against bus_error
+    if (addr == bus_error) { return BUS_ERROR; }
+
+    // Perform memory write
+    memcpy(&memory[addr], data, size);
+
+    return 0; // Write successful
+}
+
+/**
+  * @brief SRCMD Table Configurations
+  *
+  * @param srcmd_reg It could be SRCMD_EN, SRCMD_ENH, SRCMD_R, SRCMD_RH, SRCMD_W, SRCMD_WH.
+  * @param srcmd_idx It could be any legal SRCMD Table Index.
+  * @param data Value that you want to write in this register.
+  * @param num_bytes It could be 4-Byte write or 8-Byte Write.
+ **/
+void configure_srcmd_n(uint8_t srcmd_reg, uint16_t srcmd_idx, reg_intf_dw data, uint8_t num_bytes){
+    write_register(SRCMD_TABLE_BASE_OFFSET + srcmd_reg + (srcmd_idx * 32), data, num_bytes);
+}
+/**
+  * @brief MDCFG Table Configurations
+  *
+  * @param md_idx It could be any legal MDCFG Table Index.
+  * @param data Value that you want to write in this register.
+  * @param num_bytes It could be 4-Byte write or 8-Byte Write.
+ **/
+void configure_mdcfg_n(uint8_t md_idx, reg_intf_dw data, uint8_t num_bytes){
+    write_register(MDCFG_TABLE_BASE_OFFSET + (md_idx * 4),   data, num_bytes);
+}
+
+/**
+  * @brief Entry Table Configurations
+  *
+  * @param entry_reg It could be ENTRY_ADDR, ENTRY_ADDRH, ENTRY_CFG, ENTRY_USER_CFG.
+  * @param entry_idx It could be any legal Entry Table Index.
+  * @param data Value that you want to write in this register.
+  * @param num_bytes It could be 4-Byte write or 8-Byte Write.
+ **/
+void configure_entry_n(uint8_t entry_reg, uint64_t entry_idx, reg_intf_dw data, uint8_t num_bytes){
+    write_register(ENTRY_TABLE_BASE_OFFSET + entry_reg + (entry_idx * 16), data, num_bytes);    // (364 >> 2) and keeping lsb 0
+}
+
+/**
+  * @brief Receiver Port Signals
+  *
+  * @param rrid RRID Of the Bus Initiator
+  * @param addr Address to be checked
+  * @param length Number of transfers
+  * @param size It should be 0 for 1-byte, 1 for 2-byte, 2 for 4-byte access.   
+  * @param perm The permissions required for this transcation.
+  * @param iopmp_trans_req This is pointer, pass it as it is.
+ **/
+void receiver_port(uint16_t rrid, uint64_t addr, uint32_t length, uint32_t size, perm_type_e perm, iopmp_trans_req_t *iopmp_trans_req){
+    iopmp_trans_req->rrid    = rrid;
+    iopmp_trans_req->addr    = addr;
+    iopmp_trans_req->length  = length;
+    iopmp_trans_req->size    = size;
+    iopmp_trans_req->perm    = perm;
+}
+
+/**
+  * @brief error_record_check
+  *
+  * @param err_type RRID Of the Bus Initiator
+  * @param req_perm Address to be checked
+  * @param req_addr Errored Address
+  * @param err_rcd Set if error should be recorded
+ **/
+int error_record_chk(uint8_t err_type, uint8_t req_perm, uint64_t req_addr, bool err_rcd){
+    err_reqinfo_t err_req_info_temp;
+    err_req_info_temp.raw = read_register(0x0064, 4);
+    if (err_rcd){
+        FAIL_IF((err_req_info_temp.v != 1));                                                            
+        FAIL_IF((err_req_info_temp.ttype != req_perm));                                     
+        FAIL_IF((err_req_info_temp.etype != (err_type)));                                               
+        FAIL_IF((read_register(0x0068, 4) != (uint32_t)((req_addr >> 2) & 0xFFFFFFFF)));    
+        FAIL_IF((read_register(0x006C, 4) != (uint32_t)((req_addr >> 34) & 0xFFFFFFFF)));
+    }
+    else {
+        FAIL_IF((err_req_info_temp.v == 1)); 
+    }                                                   
+    
+    return 0;                                                            
+}

--- a/iopmp_ref_model/verif/test_utils.h
+++ b/iopmp_ref_model/verif/test_utils.h
@@ -1,0 +1,87 @@
+/***************************************************************************
+// Author: Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: 
+// This header file defines macros, and function prototypes
+// for the Input/Output Physical Memory Protection (IOPMP) Test file. 
+***************************************************************************/
+#include <stdio.h>
+#include <stdint.h>
+#include "iopmp.h"
+
+#define SRCMD_EN     0x00
+#define SRCMD_ENH    0x04
+#define SRCMD_R      0x08
+#define SRCMD_RH     0x0C
+#define SRCMD_W      0x10
+#define SRCMD_WH     0x14
+#define SRCMD_PERM   0x00
+#define SRCMD_PERMH  0x04
+
+#define ENTRY_ADDR      0x00
+#define ENTRY_ADDRH     0x04
+#define ENTRY_CFG       0x08
+#define ENTRY_USER_CFG  0x0C
+
+// Permissions
+#define R 0x01
+#define W 0x02
+#define X 0x04
+
+// Address Mode
+#define OFF   0x00
+#define TOR   0x08
+#define NA4   0x10
+#define NAPOT 0x18
+
+// Interrupt Suppression
+#define SIRE 0x20
+#define SIWE 0x40
+#define SIXE 0x80
+
+// Error Suppression
+#define SERE 0x100
+#define SEWE 0x200
+#define SEXE 0x400
+
+extern int test_num;
+extern int8_t *memory;
+extern uint64_t bus_error;
+
+int create_memory(uint8_t mem_gb);
+void configure_srcmd_n(uint8_t srcmd_reg, uint16_t srcmd_idx, reg_intf_dw data, uint8_t num_bytes);
+void configure_mdcfg_n(uint8_t md_idx, reg_intf_dw data, uint8_t num_bytes);
+void configure_entry_n(uint8_t entry_reg, uint64_t entry_idx, reg_intf_dw data, uint8_t num_bytes);
+void receiver_port(uint16_t rrid, uint64_t addr, uint32_t length, uint32_t size, perm_type_e perm, iopmp_trans_req_t *iopmp_trans_req);
+int error_record_chk(uint8_t err_type, uint8_t perm, uint64_t addr, bool err_rcd);
+
+// Test Macros: Define macros for IOPMP testing framework
+#define START_TEST(TEST_DESC)                           \
+    test_num++;                                         \
+    printf("Test %02d : %-61s : ", test_num, TEST_DESC)
+
+// Fails test If condition is true.
+#define FAIL_IF(CONDITION)                                                        \
+    if (CONDITION) {                                                              \
+        printf("Test %02d : \x1B[31mFAIL. Line %d\x1B[0m\n", test_num, __LINE__); \
+        return -1;                                                                \
+    }
+
+// Must be used at the end of test.
+#define END_TEST() \
+    { printf("\x1B[32mPASS\x1B[0m\n"); }
+
+// Transaction Check Macro: Verifies transaction response against expected values
+#define CHECK_IOPMP_TRANS(RSP_STATUS, ERR_TYPE)                                                         \
+    FAIL_IF((iopmp_trans_rsp.rrid != iopmp_trans_req.rrid));                                            \
+    FAIL_IF((iopmp_trans_rsp.status != (RSP_STATUS)));                                                  \
+    err_req_info_temp.raw = read_register(0x0064, 4);                                                   \
+    if (iopmp_trans_rsp.status != IOPMP_SUCCESS) {                                                      \
+        FAIL_IF((err_req_info_temp.v != 1));                                                            \
+        FAIL_IF((err_req_info_temp.ttype != iopmp_trans_req.perm));                                     \
+        FAIL_IF((err_req_info_temp.etype != (ERR_TYPE)));                                               \
+        FAIL_IF((read_register(0x0068, 4) != (uint32_t)((iopmp_trans_req.addr >> 2) & 0xFFFFFFFF)));    \
+        FAIL_IF((read_register(0x006C, 4) != (uint32_t)((iopmp_trans_req.addr >> 34) & 0xFFFFFFFF)));   \
+    } else {                                                                                            \
+        FAIL_IF((err_req_info_temp.v != 0));                                                            \
+    }

--- a/iopmp_ref_model/verif/tests/compactmodel.c
+++ b/iopmp_ref_model/verif/tests/compactmodel.c
@@ -16,14 +16,9 @@
 #include "test_utils.h"
 
 // Declarations
-// Register offset to size mapping
-uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
-int test_num;
 iopmp_trans_req_t iopmp_trans_req;
 iopmp_trans_rsp_t iopmp_trans_rsp;
-err_reqinfo_t err_req_info_temp;
-int8_t *memory;
-uint64_t bus_error;
+err_info_t err_info_temp;
 
 int main () {
 
@@ -31,18 +26,21 @@ int main () {
 
    FAIL_IF(create_memory(1) < 0)
 
+#if (SRC_ENFORCEMENT_EN == 0)
+
    START_TEST("Test OFF - Read Access permissions");
    reset_iopmp();
    // Entry Table CFG
    configure_entry_n(ENTRY_ADDR, (IOPMP_MD_ENTRY_NUM * 4),364 >> 2, 4);
    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    set_hwcfg0_enable();
 
    receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test OFF - Write Access permissions");
@@ -50,12 +48,13 @@ int main () {
    // Entry Table CFG
    configure_entry_n(ENTRY_ADDR, (IOPMP_MD_ENTRY_NUM * 4),364 >> 2, 4);
    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    set_hwcfg0_enable();
    receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test OFF - Instruction Fetch permissions");
@@ -63,12 +62,13 @@ int main () {
    // Entry Table CFG
    configure_entry_n(ENTRY_ADDR, (IOPMP_MD_ENTRY_NUM * 4),364 >> 2, 4);
    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    set_hwcfg0_enable();
    receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test OFF - UNKNOWN RRID ERROR");
@@ -76,99 +76,106 @@ int main () {
    // Entry Table CFG
    configure_entry_n(ENTRY_ADDR, (IOPMP_MD_ENTRY_NUM * 4),364 >> 2, 4);
    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    set_hwcfg0_enable();
    receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
+#if (IOPMP_TOR_EN)
    START_TEST("Test TOR - Partial hit on a priority rule error");
    reset_iopmp();
    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG  
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET, 0, 4);
    END_TEST();
 
    START_TEST("Test TOR - 4Byte Read Access");
    reset_iopmp();
    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG  
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);
+    set_hwcfg0_enable();
 
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test TOR - 4Byte Write Access");
    reset_iopmp();
    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG  
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W|R), 4);
+    set_hwcfg0_enable();
 
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test TOR - 4Byte Only Write Access");
    reset_iopmp();
    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG  
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W), 4);
+    set_hwcfg0_enable();
 
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
+#endif
 
    START_TEST("Test NA4 - 4Byte Read Access");
    reset_iopmp();
    receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG  
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);
+    set_hwcfg0_enable();
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NA4 - 4Byte No Read Access error");
    reset_iopmp();
    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
-   // Entry Table CFG  
+   // Entry Table CFG
    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);
-// IOPMP_ENTRY[1] contains top range 92
-   write_register(ENTRY_TABLE_BASE_OFFSET + 0x8 + ((iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)) * 16),   (NA4), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
-
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4), 4);
+   set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NA4 - 4Byte Write Access");
@@ -177,15 +184,16 @@ int main () {
 
    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG  
+   // Entry Table CFG
    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);
-// IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NA4 - 4Byte No Write Access error");
@@ -194,14 +202,15 @@ int main () {
 
    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG  
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NA4 - 4Byte Execute Access");
@@ -210,14 +219,15 @@ int main () {
 
    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
-   // Entry Table CFG  
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|X|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|X|W|R), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NA4 - 4Byte No Execute Access");
@@ -226,14 +236,15 @@ int main () {
 
    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
-   // Entry Table CFG  
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NA4 - 8Byte Access error");
@@ -242,14 +253,15 @@ int main () {
 
    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NA4 - For exact 4 Byte error");
@@ -258,47 +270,50 @@ int main () {
 
    receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NAPOT - 8 Byte read access");
    // Reset IOPMP
    reset_iopmp();
-   
+
    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|R), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NAPOT - 8 Byte read access error");
    // Reset IOPMP
    reset_iopmp();
-   
+
    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W), 4);
+    set_hwcfg0_enable();
 
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NAPOT - 8 Byte write access error");
@@ -307,14 +322,15 @@ int main () {
 
    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NAPOT - 8 Byte write access");
@@ -323,45 +339,48 @@ int main () {
 
    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
-   // Entry Table CFG 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W|R), 4);
+    set_hwcfg0_enable();
 
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NAPOT - 8 Byte Instruction access error");
    reset_iopmp();
    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-   // Entry Table CFG 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);
+    set_hwcfg0_enable();
 
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NAPOT - 8 Byte Instruction access");
    // Reset
    reset_iopmp();
    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   // Entry Table CFG 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);
+    set_hwcfg0_enable();
 
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
@@ -369,19 +388,22 @@ int main () {
    reset_iopmp();
    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 74, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 74, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);
+    set_hwcfg0_enable();
 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x18, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x18, 4);
+    set_hwcfg0_enable();
 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Entry_LCK, updating locked ENTRY field");
@@ -390,32 +412,34 @@ int main () {
 
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-   // Entry Table CFG 
+   // Entry Table CFG
    write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
-   
+
    reset_iopmp();
 
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-   // Entry Table CFG 
+   // Entry Table CFG
    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[15] are locked
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Entry_LCK register lock bit");
@@ -423,26 +447,28 @@ int main () {
    reset_iopmp();
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-   // Entry Table CFG 
-   write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
-   write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
-   write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // Entry Table CFG
+   write_register(ENTRYLCK_OFFSET,   0x1000, 4);  // ENTRY[0]-ENTRY[15] are locked
+   write_register(ENTRYLCK_OFFSET,   0x1, 4);     // ENTRYLCK is locked
+   write_register(ENTRYLCK_OFFSET,   0x2, 4);     // ENTRY[0] is locked
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
    END_TEST();
 
    START_TEST("Test MFR Extension");
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   // Entry Table CFG 
+   // Entry Table CFG
    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);
+    set_hwcfg0_enable();
 
 
    // requestor Port Signals
@@ -450,28 +476,29 @@ int main () {
    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
    FAIL_IF((err_mfr_temp.svw != 0));
    FAIL_IF((err_mfr_temp.svs != 0));
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
-   FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+   FAIL_IF((err_mfr_temp.svi != 0));
    FAIL_IF((err_mfr_temp.svs != 1));
-   FAIL_IF((err_mfr_temp.svw != 1));
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
-   END_TEST();    
+   FAIL_IF((err_mfr_temp.svw != 4));
+   write_register(ERR_INFO_OFFSET,   0, 4);
+   END_TEST();
 
    START_TEST("Test Interrupt Suppression is Enabled");
    reset_iopmp();
    write_register(ERR_OFFSET,   0x2, 4);
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);     // (364 >> 2) and keeping lsb 0
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+    set_hwcfg0_enable();
+
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Interrupt Suppression is disabled");
@@ -480,65 +507,69 @@ int main () {
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
-   
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
-   END_TEST();   
+   write_register(ERR_INFO_OFFSET,   0, 4);
+   END_TEST();
 
    START_TEST("Test Error Suppression is Enabled");
    // Receiver Port Signals
    reset_iopmp();
    write_register(ERR_OFFSET,   0x4, 4);
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);             // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE|NAPOT|R), 4);  // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
    FAIL_IF((iopmp_trans_rsp.rrid != 2));
    FAIL_IF((iopmp_trans_rsp.user != USER));
    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Error Suppression is Enabled but rs is zero");
    // Receiver Port Signals
    reset_iopmp();
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);             // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE|NAPOT|R), 4);  // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
    FAIL_IF((iopmp_trans_rsp.rrid != 2));
    FAIL_IF((iopmp_trans_rsp.user != USER));
    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Error Suppression is disabled");
    // Receiver Port Signals
    reset_iopmp();
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);         // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);   // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
    FAIL_IF((iopmp_trans_rsp.rrid != 2));
    FAIL_IF((iopmp_trans_rsp.user != 0));
    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Interrupt and Error Suppression is Enabled");
@@ -546,18 +577,19 @@ int main () {
    reset_iopmp();
    write_register(ERR_OFFSET,   0x6, 4);
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);                         // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE | SIXE | NAPOT | R), 4);   // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((intrpt == 1));
    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
    FAIL_IF((iopmp_trans_rsp.rrid != 2));
    FAIL_IF((iopmp_trans_rsp.user != USER));
    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Interrupt and Error Suppression is disabled");
@@ -565,52 +597,142 @@ int main () {
    reset_iopmp();
    write_register(ERR_OFFSET,   0x2, 4);
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);            // (364 >> 2) and keeping lsb 0
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-   FAIL_IF((intrpt != 1)); 
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+   FAIL_IF((intrpt != 1));
    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
    FAIL_IF((iopmp_trans_rsp.rrid != 2));
    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
-   END_TEST();   
+   write_register(ERR_INFO_OFFSET,   0, 4);
+   END_TEST();
 
+#if (IOPMP_RRID_TRANSL_EN)
    START_TEST("Test Cascading IOPMP Feature");
    reset_iopmp();
    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 0x1B, 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
-   END_TEST();
-
-#if (MSI_EN)
-   START_TEST("Test MSI");
-   uint32_t read_data;
-   reset_iopmp();
-   write_register(ERR_OFFSET, 0x8F0A, 4);
-   write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
-   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
-
-   // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-   read_memory(0x8000, 4, (char *)&read_data);
-   FAIL_IF(intrpt == 1);
-   FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
-   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 #endif
+
+#if (MSI_EN)
+    START_TEST("Test MSI Write error");
+    uint64_t read_data;
+    reset_iopmp();
+    bus_error = 0x8000;
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
+    set_hwcfg0_enable();
+
+    // Requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    bus_error = 0;
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data == 0x8F); // Interrupt is not suppressed
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MSI");
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
+    set_hwcfg0_enable();
+
+    // Requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+#endif
    free(memory);
+
+#if (SRC_ENFORCEMENT_EN)
+    START_TEST("Test SourceEnforcement Enable Feature");
+    reset_iopmp();
+    configure_entry_n(ENTRY_ADDR, 0, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 0, (NAPOT | W | R), 4);
+    set_hwcfg0_enable();
+
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+
+    receiver_port(12, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+#if ((STALL_BUF_DEPTH != 0) & (IMP_RRIDSCP))
+    START_TEST("Stall MD Feature");
+    // reset_iopmp();
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT | X), 4);
+    set_hwcfg0_enable();
+    write_register(MDSTALL_OFFSET, 0x40, 4);
+    write_register(RRISCP_OFFSET,5,4);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#elif (INM_RRIDSCP)
+    // Set STALL_BUF_DEPTH zero to test this feature
+    START_TEST("Faulting Stalled Transactions Feature");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x10, 4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT | X), 4);
+    set_hwcfg0_enable();
+    write_register(MDSTALL_OFFSET, 0x40, 4);
+    write_register(RRISCP_OFFSET,5,4);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, STALLED_TRANSACTION);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
 
    return 0;
 }

--- a/iopmp_ref_model/verif/tests/compactmodel.c
+++ b/iopmp_ref_model/verif/tests/compactmodel.c
@@ -1,0 +1,616 @@
+/***************************************************************************
+// Author: Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the tests that are used to test
+// compact-k model.
+// Max Supported RRIDs: 63
+// Max Supported MDs: 63
+// There is no physical SRCMD table. RRID i directly maps to MD i.
+// There is no physical MDCFG table. Each MD has k associated IOPMP entries.
+// Associated IOPMP Entry Ranges:
+// (i × k) to ((i + 1) × k - 1) for address matching and permission checks.
+***************************************************************************/
+
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+// Declarations
+// Register offset to size mapping
+uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
+int test_num;
+iopmp_trans_req_t iopmp_trans_req;
+iopmp_trans_rsp_t iopmp_trans_rsp;
+err_reqinfo_t err_req_info_temp;
+int8_t *memory;
+uint64_t bus_error;
+
+int main () {
+
+   uint8_t intrpt;
+
+   FAIL_IF(create_memory(1) < 0)
+
+   START_TEST("Test OFF - Read Access permissions");
+   reset_iopmp();
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (IOPMP_MD_ENTRY_NUM * 4),364 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+
+   receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test OFF - Write Access permissions");
+   reset_iopmp();
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (IOPMP_MD_ENTRY_NUM * 4),364 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+   receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test OFF - Instruction Fetch permissions");
+   reset_iopmp();
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (IOPMP_MD_ENTRY_NUM * 4),364 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+   receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test OFF - UNKNOWN RRID ERROR");
+   reset_iopmp();
+   // Entry Table CFG
+   configure_entry_n(ENTRY_ADDR, (IOPMP_MD_ENTRY_NUM * 4),364 >> 2, 4);
+   configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+   receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test TOR - Partial hit on a priority rule error");
+   reset_iopmp();
+   receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG  
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test TOR - 4Byte Read Access");
+   reset_iopmp();
+   receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG  
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test TOR - 4Byte Write Access");
+   reset_iopmp();
+   receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG  
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test TOR - 4Byte Only Write Access");
+   reset_iopmp();
+   receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG  
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NA4 - 4Byte Read Access");
+   reset_iopmp();
+   receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG  
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NA4 - 4Byte No Read Access error");
+   reset_iopmp();
+   receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+   // Entry Table CFG  
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);
+// IOPMP_ENTRY[1] contains top range 92
+   write_register(ENTRY_TABLE_BASE_OFFSET + 0x8 + ((iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)) * 16),   (NA4), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NA4 - 4Byte Write Access");
+   // Reset IOPMP
+   reset_iopmp();
+
+   receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG  
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);
+// IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NA4 - 4Byte No Write Access error");
+   // Reset
+   reset_iopmp();
+
+   receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG  
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NA4 - 4Byte Execute Access");
+   // Reset IOPMP
+   reset_iopmp();
+
+   receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+   // Entry Table CFG  
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|X|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NA4 - 4Byte No Execute Access");
+   // Reset IOPMP
+   reset_iopmp();
+
+   receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+   // Entry Table CFG  
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NA4 - 8Byte Access error");
+   // Reset
+   reset_iopmp();
+
+   receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG 
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NA4 - For exact 4 Byte error");
+   // Reset
+   reset_iopmp();
+
+   receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG 
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 364 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NAPOT - 8 Byte read access");
+   // Reset IOPMP
+   reset_iopmp();
+   
+   receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG 
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NAPOT - 8 Byte read access error");
+   // Reset IOPMP
+   reset_iopmp();
+   
+   receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG 
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NAPOT - 8 Byte write access error");
+   // Reset IOPMP
+   reset_iopmp();
+
+   receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG 
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NAPOT - 8 Byte write access");
+   // Reset IOPMP
+   reset_iopmp();
+
+   receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+   // Entry Table CFG 
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NAPOT - 8 Byte Instruction access error");
+   reset_iopmp();
+   receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+   // Entry Table CFG 
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NAPOT - 8 Byte Instruction access");
+   // Reset
+   reset_iopmp();
+   receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   // Entry Table CFG 
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
+   // Receiver Port Signals
+   reset_iopmp();
+   receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 74, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x18, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Entry_LCK, updating locked ENTRY field");
+   // Reset IOPMP
+   reset_iopmp();
+
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+   // Entry Table CFG 
+   write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
+   
+   reset_iopmp();
+
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+   // Entry Table CFG 
+   write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[15] are locked
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Entry_LCK register lock bit");
+
+   reset_iopmp();
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+   // Entry Table CFG 
+   write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
+   write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+   write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+   END_TEST();
+
+   START_TEST("Test MFR Extension");
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   // Entry Table CFG 
+   write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+   write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+   write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+   // requestor Port Signals
+   err_mfr_t err_mfr_temp;
+   err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+   FAIL_IF((err_mfr_temp.svw != 0));
+   FAIL_IF((err_mfr_temp.svs != 0));
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+   err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+   FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+   FAIL_IF((err_mfr_temp.svs != 1));
+   FAIL_IF((err_mfr_temp.svw != 1));
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();    
+
+   START_TEST("Test Interrupt Suppression is Enabled");
+   reset_iopmp();
+   write_register(ERR_OFFSET,   0x2, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Interrupt Suppression is disabled");
+   reset_iopmp();
+   write_register(ERR_OFFSET,   0x2, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();   
+
+   START_TEST("Test Error Suppression is Enabled");
+   // Receiver Port Signals
+   reset_iopmp();
+   write_register(ERR_OFFSET,   0x4, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+   FAIL_IF((iopmp_trans_rsp.rrid != 2));
+   FAIL_IF((iopmp_trans_rsp.user != USER));
+   error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Error Suppression is Enabled but rs is zero");
+   // Receiver Port Signals
+   reset_iopmp();
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+   FAIL_IF((iopmp_trans_rsp.rrid != 2));
+   FAIL_IF((iopmp_trans_rsp.user != USER));
+   error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Error Suppression is disabled");
+   // Receiver Port Signals
+   reset_iopmp();
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+   FAIL_IF((iopmp_trans_rsp.rrid != 2));
+   FAIL_IF((iopmp_trans_rsp.user != 0));
+   error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Interrupt and Error Suppression is Enabled");
+   // Receiver Port Signals
+   reset_iopmp();
+   write_register(ERR_OFFSET,   0x6, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((intrpt == 1));
+   FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+   FAIL_IF((iopmp_trans_rsp.rrid != 2));
+   FAIL_IF((iopmp_trans_rsp.user != USER));
+   error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Interrupt and Error Suppression is disabled");
+   // Receiver Port Signals
+   reset_iopmp();
+   write_register(ERR_OFFSET,   0x2, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((intrpt != 1)); 
+   FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+   FAIL_IF((iopmp_trans_rsp.rrid != 2));
+   error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();   
+
+   START_TEST("Test Cascading IOPMP Feature");
+   reset_iopmp();
+   receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 0x1B, 4);
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+#if (MSI_EN)
+   START_TEST("Test MSI");
+   uint32_t read_data;
+   reset_iopmp();
+   write_register(ERR_OFFSET, 0x8F0A, 4);
+   write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   read_memory(0x8000, 4, (char *)&read_data);
+   FAIL_IF(intrpt == 1);
+   FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+#endif
+   free(memory);
+
+   return 0;
+}

--- a/iopmp_ref_model/verif/tests/dynamicmodel.c
+++ b/iopmp_ref_model/verif/tests/dynamicmodel.c
@@ -1,0 +1,863 @@
+/***************************************************************************
+// Author: Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the tests that are used to test
+// dynamic-k model.
+// Max Supported RRIDs: 65536
+// Max Supported MDs: 63
+// Uses the RRID to obtain SRCMD_EN(H), indicating the associated MDs.
+// There is no physical MDCFG table in this model. Each MD has k associated 
+// IOPMP entries. IOPMP entries linked to the MD associated with
+// the RRID are traversed for address matching and permission checks.
+// The value of k is programmable. IOPMP Entry Ranges for Each MD:
+// MD0 → 0 to (k - 1)
+// MD1 → k to (2k - 1)
+// MD2 → 2k to (3k - 1), and so on.
+***************************************************************************/
+
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+// Declarations
+// Register offset to size mapping
+uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
+int test_num;
+iopmp_trans_req_t iopmp_trans_req;
+iopmp_trans_rsp_t iopmp_trans_rsp;
+err_reqinfo_t err_req_info_temp;
+int8_t *memory;
+uint64_t bus_error;
+
+int main () {
+
+    uint8_t intrpt;
+
+    FAIL_IF(create_memory(1) < 0)
+
+    START_TEST("Test OFF - Read Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),(364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Write Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),(364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Instruction Fetch permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),(364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - UNKNOWN RRID ERROR");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),(364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - Partial hit on a priority rule error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4); // SRCMD_R[2] is associated with MD[3]
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4); // SRCMD_R[2] is associated with MD[3]
+    write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access with SRCMD_R not set");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+#if (IOPMP_SPS_EN == 0)
+    START_TEST("Test TOR - 4Byte Read Access, SRCMD_R not set, SPS disabled");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);                   // SRCMD_EN[2] is associated with MD[3]
+    // Entry Table CFG
+    write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFFFFFFDF, 4);   // Disabling SPS extension
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);        // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);  // SRCMD_R[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4); // SRCMD_W[2] is associated with MD[3]
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0xB, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);        // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);  // SRCMD_R[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4); // SRCMD_W[2] is associated with MD[3]
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0xA, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Read Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x10, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No SPS Read Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x00, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Write Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No SPS Write Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x00, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x17, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No SPS.R, Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x00, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x17, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 8Byte Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(32, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - For exact 4 Byte error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),(364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);
+    receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x19, 4);
+    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x18, 4);
+    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x18, 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1B, 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x18, 4);
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 31, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 31, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),74, 4);    // (300 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+
+    configure_srcmd_n(SRCMD_EN, 32, 0x20, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x20, 4);
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 4),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 4), 0x18, 4);
+
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 4),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 4), 0x1C, 4);
+    iopmp_trans_req.rrid     = 32;
+    iopmp_trans_req.addr     = 360;
+    iopmp_trans_req.length   = 0;
+    iopmp_trans_req.size     = 3;
+    iopmp_trans_req.perm     = INSTR_FETCH;
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating locked srcmd_en field");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x10, 4);
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating unlocked srcmd_en field");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x8, 4);
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating locked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test SRCMD_EN lock bit, updating locked SRCMD Table");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x1, 4);   // SRCMD_EN[2] lock bit is set
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test SRCMD_EN lock bit, updating unlocked SRCMD Table");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1, 4);   // SRCMD_EN[1] lock bit is set
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK register lock bit");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x8, 4);          // MD[2] is locked
+    write_register(MDLCK_OFFSET,   0x1, 4);          // Locking MDLCK register
+    write_register(MDLCK_OFFSET,   0x10, 4);         // Trying to lock MD[3] but it shouldn't be locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK register lock bit");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    END_TEST();
+
+
+    START_TEST("Test MFR Extension");
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    err_mfr_t err_mfr_temp;
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svw != 0));
+    FAIL_IF((err_mfr_temp.svs != 0));
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svs != 1));
+    FAIL_IF((err_mfr_temp.svw != 1));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating locked srcmd_enh field");
+    reset_iopmp();
+    write_register(MDLCKH_OFFSET,   0x1, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating unlocked srcmd_enh field");
+    reset_iopmp();
+    write_register(MDLCKH_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt Suppression is Enabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt Suppression is disabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT|R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x4, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is Enabled but rs is zero");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != 0));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x6, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt != 1)); 
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Stall MD Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 5, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 5, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Cascading IOPMP Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1B, 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+#if (MSI_EN)
+    START_TEST("Test MSI");
+    uint32_t read_data;
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT | R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    read_memory(0x8000, 4, (char *)&read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+    free(memory);
+
+    return 0;
+}

--- a/iopmp_ref_model/verif/tests/dynamicmodel.c
+++ b/iopmp_ref_model/verif/tests/dynamicmodel.c
@@ -6,10 +6,10 @@
 // Max Supported RRIDs: 65536
 // Max Supported MDs: 63
 // Uses the RRID to obtain SRCMD_EN(H), indicating the associated MDs.
-// There is no physical MDCFG table in this model. Each MD has k associated 
+// There is no physical MDCFG table in this model. Each MD has k associated
 // IOPMP entries. IOPMP entries linked to the MD associated with
 // the RRID are traversed for address matching and permission checks.
-// The value of k is programmable. IOPMP Entry Ranges for Each MD:
+// The value of k is programmable. IOPMP Entry Ranges for Each MD
 // MD0 → 0 to (k - 1)
 // MD1 → k to (2k - 1)
 // MD2 → 2k to (3k - 1), and so on.
@@ -20,14 +20,9 @@
 #include "test_utils.h"
 
 // Declarations
-// Register offset to size mapping
-uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
-int test_num;
 iopmp_trans_req_t iopmp_trans_req;
 iopmp_trans_rsp_t iopmp_trans_rsp;
-err_reqinfo_t err_req_info_temp;
-int8_t *memory;
-uint64_t bus_error;
+err_info_t err_info_temp;
 
 int main () {
 
@@ -35,6 +30,7 @@ int main () {
 
     FAIL_IF(create_memory(1) < 0)
 
+#if (SRC_ENFORCEMENT_EN == 0)
     START_TEST("Test OFF - Read Access permissions");
     reset_iopmp();
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
@@ -42,12 +38,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),(364 >> 2), 4);
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Write Access permissions");
@@ -57,12 +54,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),(364 >> 2), 4);
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Instruction Fetch permissions");
@@ -72,12 +70,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),(364 >> 2), 4);
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - UNKNOWN RRID ERROR");
@@ -87,59 +86,64 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),(364 >> 2), 4);
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
+#if (IOPMP_TOR_EN)
     START_TEST("Test TOR - Partial hit on a priority rule error");
     reset_iopmp();
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
-    configure_srcmd_n(SRCMD_R, 2, 0x10, 4); // SRCMD_R[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);        // SRCMD_R[2] is associated with MD[3]
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Read Access");
     reset_iopmp();
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
-    configure_srcmd_n(SRCMD_R, 2, 0x10, 4); // SRCMD_R[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);        // SRCMD_R[2] is associated with MD[3]
     write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);
+    set_hwcfg0_enable();
 
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Read Access with SRCMD_R not set");
     reset_iopmp();
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);
+    set_hwcfg0_enable();
 
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
 #if (IOPMP_SPS_EN == 0)
@@ -148,65 +152,69 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);                   // SRCMD_EN[2] is associated with MD[3]
     // Entry Table CFG
     write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFFFFFFDF, 4);   // Disabling SPS extension
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x9, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 #endif
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);        // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4); // SRCMD_EN[2] is associated with MD[3]
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);  // SRCMD_R[2] is associated with MD[3]
-    configure_srcmd_n(SRCMD_W, 2, 0x10, 4); // SRCMD_W[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4);  // SRCMD_W[2] is associated with MD[3]
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0xB, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0xB, 4);
+    set_hwcfg0_enable();
 
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);        // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4); // SRCMD_EN[2] is associated with MD[3]
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);  // SRCMD_R[2] is associated with MD[3]
-    configure_srcmd_n(SRCMD_W, 2, 0x10, 4); // SRCMD_W[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4);  // SRCMD_W[2] is associated with MD[3]
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0xA, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0xA, 4);
+    set_hwcfg0_enable();
 
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
-
+#endif
     START_TEST("Test NA4 - 4Byte Read Access");
     reset_iopmp();
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);
+    set_hwcfg0_enable();
 
     receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Read Access error");
@@ -214,15 +222,16 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x10, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x10, 4);
+    set_hwcfg0_enable();
 
     receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No SPS Read Access error");
@@ -230,15 +239,16 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 32, 0x00, 4);
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);
+    set_hwcfg0_enable();
 
     receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Write Access");
@@ -247,15 +257,16 @@ int main () {
     configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
     configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);
+    set_hwcfg0_enable();
 
     receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Write Access error");
@@ -263,15 +274,16 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
     configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);
+    set_hwcfg0_enable();
 
     receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No SPS Write Access error");
@@ -279,15 +291,16 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
     configure_srcmd_n(SRCMD_W, 32, 0x00, 4);
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);
+    set_hwcfg0_enable();
 
     receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Execute Access");
@@ -295,15 +308,16 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x17, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x17, 4);
+    set_hwcfg0_enable();
 
     receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Execute Access");
@@ -311,15 +325,16 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);
+    set_hwcfg0_enable();
 
     receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No SPS.R, Execute Access");
@@ -327,15 +342,16 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 32, 0x00, 4);
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x17, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x17, 4);
+    set_hwcfg0_enable();
 
     receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 8Byte Access error");
@@ -343,14 +359,15 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
     // Entry Table CFG
-    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - For exact 4 Byte error");
@@ -360,12 +377,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),(364 >> 2), 4);
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access");
@@ -375,12 +393,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x19, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access error");
@@ -390,12 +409,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access error");
@@ -405,12 +425,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access");
@@ -421,12 +442,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1B, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access error");
@@ -436,12 +458,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access");
@@ -451,12 +474,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
@@ -466,14 +490,17 @@ int main () {
     configure_srcmd_n(SRCMD_R, 31, 0x10, 4);
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),74, 4);    // (300 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
 
     configure_srcmd_n(SRCMD_EN, 32, 0x20, 4);
     configure_srcmd_n(SRCMD_R, 32, 0x20, 4);
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 4),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 4), 0x18, 4);
+    set_hwcfg0_enable();
 
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 4),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 4), 0x1C, 4);
+    set_hwcfg0_enable();
     iopmp_trans_req.rrid     = 32;
     iopmp_trans_req.addr     = 360;
     iopmp_trans_req.length   = 0;
@@ -481,9 +508,9 @@ int main () {
     iopmp_trans_req.perm     = INSTR_FETCH;
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK, updating locked srcmd_en field");
@@ -494,12 +521,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK, updating unlocked srcmd_en field");
@@ -510,12 +538,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating locked ENTRY field");
@@ -526,12 +555,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
@@ -541,12 +571,13 @@ int main () {
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test SRCMD_EN lock bit, updating locked SRCMD Table");
@@ -557,12 +588,13 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test SRCMD_EN lock bit, updating unlocked SRCMD Table");
@@ -572,12 +604,13 @@ int main () {
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK register lock bit");
@@ -590,28 +623,30 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK register lock bit");
     reset_iopmp();
-    write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
-    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
-    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    write_register(ENTRYLCK_OFFSET,   0x1000, 4);  // ENTRY[0]-ENTRY[15] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);     // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);     // ENTRY[0] is locked
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
@@ -625,6 +660,7 @@ int main () {
     // Entry Table CFG
     configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3),90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
@@ -632,13 +668,13 @@ int main () {
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
     FAIL_IF((err_mfr_temp.svw != 0));
     FAIL_IF((err_mfr_temp.svs != 0));
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
-    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svi != 0));
     FAIL_IF((err_mfr_temp.svs != 1));
-    FAIL_IF((err_mfr_temp.svw != 1));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    FAIL_IF((err_mfr_temp.svw != 4));
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK, updating locked srcmd_enh field");
@@ -648,12 +684,13 @@ int main () {
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK, updating unlocked srcmd_enh field");
@@ -663,12 +700,13 @@ int main () {
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt Suppression is Enabled");
@@ -677,14 +715,15 @@ int main () {
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
-    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 0x99, 4);  // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1)); // Interrupt is suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt Suppression is disabled");
@@ -694,13 +733,14 @@ int main () {
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);
     configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT|R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is Enabled");
@@ -709,17 +749,18 @@ int main () {
     write_register(ERR_OFFSET,   0x4, 4);
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
-    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);              // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE|NAPOT|R), 4);   // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is Enabled but rs is zero");
@@ -727,17 +768,18 @@ int main () {
     reset_iopmp();
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
-    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);              // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE|NAPOT|R), 4);   // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is disabled");
@@ -745,17 +787,18 @@ int main () {
     reset_iopmp();
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != 0));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is Enabled");
@@ -764,18 +807,19 @@ int main () {
     write_register(ERR_OFFSET,   0x6, 4);
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);                          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is disabled");
@@ -784,39 +828,68 @@ int main () {
     write_register(ERR_OFFSET,   0x2, 4);
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);            // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    FAIL_IF((intrpt != 1)); 
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((intrpt != 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
+#if ((STALL_BUF_DEPTH != 0) & (IMP_RRIDSCP))
     START_TEST("Stall MD Feature");
     reset_iopmp();
     configure_srcmd_n(SRCMD_EN, 5, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 5, 0x10, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
     write_register(MDSTALL_OFFSET, 0x10, 4);
     write_register(RRISCP_OFFSET,5,4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
     rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#elif (IMP_RRIDSCP)
+    // Set STALL_BUF_DEPTH zero to test this feature
+    START_TEST("Faulting Stalled Transactions Feature");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x10, 4);
+    configure_srcmd_n(SRCMD_EN, 5, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 5, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    set_hwcfg0_enable();
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, STALLED_TRANSACTION);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+#if (IOPMP_RRID_TRANSL_EN)
     START_TEST("Test Cascading IOPMP Feature");
     reset_iopmp();
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
@@ -824,40 +897,91 @@ int main () {
     configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1B, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
 #if (MSI_EN)
-    START_TEST("Test MSI");
-    uint32_t read_data;
+    START_TEST("Test MSI Write error");
+    uint64_t read_data;
     reset_iopmp();
+    bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
-    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);
     configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    read_memory(0x8000, 4, (char *)&read_data);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    bus_error = 0;
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data == 0x8F); // Interrupt is not suppressed
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MSI");
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT | R), 4);
+    set_hwcfg0_enable();
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    read_memory(0x8000, 4, &read_data);
     FAIL_IF(intrpt == 1);
     FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 #endif
 
     free(memory);
+
+#if (SRC_ENFORCEMENT_EN)
+    START_TEST("Test SourceEnforcement Enable Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 0, 0x02, 4);
+    configure_srcmd_n(SRCMD_R, 0, 0x02, 4);
+    configure_srcmd_n(SRCMD_W, 0, 0x02, 4);
+    configure_entry_n(ENTRY_ADDR, 0, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 0, (NAPOT | W | R), 4);
+    set_hwcfg0_enable();
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+
+    receiver_port(12, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
 
     return 0;
 }

--- a/iopmp_ref_model/verif/tests/fullmodel.c
+++ b/iopmp_ref_model/verif/tests/fullmodel.c
@@ -12,20 +12,15 @@
 #include "test_utils.h"
 
 // Declarations
-// Register offset to size mapping
-uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
-int test_num;
 iopmp_trans_req_t iopmp_trans_req;
 iopmp_trans_rsp_t iopmp_trans_rsp;
-err_reqinfo_t err_req_info_temp;
-int8_t *memory;
-uint64_t bus_error;
+err_info_t err_info_temp;
 
 int main () {
     uint8_t intrpt;
 
     FAIL_IF(create_memory(1) < 0)
-
+#if (SRC_ENFORCEMENT_EN == 0)
     START_TEST("Test OFF - Read Access permissions");
     reset_iopmp();
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
@@ -33,12 +28,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (OFF | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Write Access permissions");
@@ -48,12 +44,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (OFF | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Instruction Fetch permissions");
@@ -63,12 +60,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (OFF | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - UNKNOWN RRID ERROR");
@@ -78,106 +76,116 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (OFF | R), 4);
+    set_hwcfg0_enable();
     receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
+#if (IOPMP_TOR_EN)
     START_TEST("Test TOR - Partial hit on a priority rule error");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
-    configure_srcmd_n(SRCMD_R, 2, 0x10, 4); // SRCMD_R[2] is associated with MD[3]
-    configure_mdcfg_n(3, 2, 4);           // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);    // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);     // SRCMD_R[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);                 // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+
 
     START_TEST("Test TOR - 4Byte Read Access");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
-    configure_srcmd_n(SRCMD_R, 2, 0x10, 4); // SRCMD_R[2] is associated with MD[3]
-    configure_mdcfg_n(3, 2, 4);           // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);    // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);     // SRCMD_R[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);                 // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Read Access with SRCMD_R not set");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
-    configure_mdcfg_n(3, 2, 4);           // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);    // SRCMD_EN[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);                 // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
 #if (IOPMP_SPS_EN == 0)
     START_TEST("Test TOR - 4Byte Read Access, SRCMD_R not set, SPS disabled");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);                   // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);          // SRCMD_EN[2] is associated with MD[3]
     configure_mdcfg_n(3, 2, 4);                       // MDCFG[3].t contains 2
     write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFFFFFFDF, 4);   // Disabling SPS extension
-    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);             // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);              // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 #endif
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);        // SRCMD_EN[2] is associated with MD[3]
-    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);  // SRCMD_R[2] is associated with MD[3]
-    configure_srcmd_n(SRCMD_W, 2, 0x10, 4); // SRCMD_W[2] is associated with MD[3]
-    configure_mdcfg_n(3, 2, 4);            // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);    // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);     // SRCMD_R[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4);     // SRCMD_W[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);                 // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (TOR | W | R), 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);        // SRCMD_EN[2] is associated with MD[3]
-    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);  // SRCMD_R[2] is associated with MD[3]
-    configure_srcmd_n(SRCMD_W, 2, 0x10, 4); // SRCMD_W[2] is associated with MD[3]
-    configure_mdcfg_n(3, 2, 4);            // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);    // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);     // SRCMD_R[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4);     // SRCMD_W[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);                 // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (TOR | W), 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test NA4 - 4Byte Read Access");
     reset_iopmp();
@@ -186,12 +194,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4 | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Read Access error");
@@ -201,12 +210,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No SPS Read Access error");
@@ -216,12 +226,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4 | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Write Access");
@@ -232,12 +243,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4 | W | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Write Access error");
@@ -247,12 +259,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4 | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No SPS Write Access error");
@@ -262,12 +275,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4 | W | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Execute Access");
@@ -277,12 +291,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4 | X | W | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Execute Access");
@@ -292,12 +307,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4 | W | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No SPS.R, Execute Access");
@@ -307,12 +323,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4 | X | W | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 8Byte Access error");
@@ -322,12 +339,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4 | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - For exact 4 Byte error");
@@ -337,12 +355,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
     configure_entry_n(ENTRY_CFG, 1, (NA4 | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access");
@@ -352,12 +371,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access error");
@@ -367,12 +387,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access error");
@@ -382,12 +403,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access");
@@ -398,12 +420,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | W | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access error");
@@ -413,12 +436,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access");
@@ -428,12 +452,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
@@ -443,21 +468,24 @@ int main () {
     configure_mdcfg_n(3, 17, 4);
     configure_entry_n(ENTRY_ADDR, 1,  74, 4);    // (300 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
-    
+    set_hwcfg0_enable();
+
     configure_srcmd_n(SRCMD_EN, 32, 0x20, 4);
     configure_srcmd_n(SRCMD_R, 32, 0x20, 4);
     configure_mdcfg_n(4, 25, 4);
     configure_entry_n(ENTRY_ADDR, 18,  90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 18, (NAPOT), 4);
+    set_hwcfg0_enable();
 
     configure_entry_n(ENTRY_ADDR, 20,  90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 20, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK, updating locked srcmd_en field");
@@ -468,12 +496,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK, updating unlocked srcmd_en field");
@@ -484,44 +513,47 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDCFG_LCK, updating locked MDCFG field");
     reset_iopmp();
-    write_register(MDCFGLCK_OFFSET,   0x8, 4);   // MD[0]-MD[3] are locked
+    write_register(MDCFGLCK_OFFSET,   0x8, 4);  // MD[0]-MD[3] are locked
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_mdcfg_n(3, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDCFG_LCK, updating unlocked MDCFG field");
     reset_iopmp();
-    write_register(MDCFGLCK_OFFSET,   0x4, 4);   // MD[0]-MD[1] are locked
+    write_register(MDCFGLCK_OFFSET,   0x4, 4);  // MD[0]-MD[1] are locked
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_mdcfg_n(3, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating locked ENTRY field");
@@ -530,14 +562,15 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_mdcfg_n(3, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
@@ -548,44 +581,47 @@ int main () {
     configure_mdcfg_n(3, 5, 4);
     configure_entry_n(ENTRY_ADDR, 4,  90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 4, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test SRCMD_EN lock bit, updating locked SRCMD Table");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_EN, 2, 0x1, 4);   // SRCMD_EN[2] lock bit is set
+    configure_srcmd_n(SRCMD_EN, 2, 0x1, 4);    // SRCMD_EN[2] lock bit is set
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test SRCMD_EN lock bit, updating unlocked SRCMD Table");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_EN, 1, 0x1, 4);   // SRCMD_EN[1] lock bit is set
+    configure_srcmd_n(SRCMD_EN, 1, 0x1, 4);      // SRCMD_EN[1] lock bit is set
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_mdcfg_n(3, 5, 4);
     configure_entry_n(ENTRY_ADDR, 4,  90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 4, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK register lock bit");
@@ -596,14 +632,15 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_mdcfg_n(3, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);         // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
 
@@ -615,14 +652,15 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_mdcfg_n(3, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK register lock bit");
@@ -633,12 +671,13 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_mdcfg_n(3, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
@@ -650,8 +689,9 @@ int main () {
     configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
     configure_mdcfg_n(3, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
@@ -659,13 +699,13 @@ int main () {
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
     FAIL_IF((err_mfr_temp.svw != 0));
     FAIL_IF((err_mfr_temp.svs != 0));
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
-    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svi != 0));
     FAIL_IF((err_mfr_temp.svs != 1));
-    FAIL_IF((err_mfr_temp.svw != 1));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    FAIL_IF((err_mfr_temp.svw != 4));
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK, updating locked srcmd_enh field");
@@ -676,12 +716,13 @@ int main () {
     configure_mdcfg_n(31, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK, updating unlocked srcmd_enh field");
@@ -692,13 +733,14 @@ int main () {
     configure_mdcfg_n(31, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST(); 
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
     START_TEST("Test Interrupt Suppression is Enabled");
     reset_iopmp();
@@ -706,15 +748,16 @@ int main () {
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);                   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((intrpt == 1));                                    // Interrupt is suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt Suppression is disabled");
@@ -725,14 +768,15 @@ int main () {
     configure_mdcfg_n(31, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
     START_TEST("Test Error Suppression is Enabled");
     // Receiver Port Signals
@@ -741,17 +785,18 @@ int main () {
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);                   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is Enabled but rs is zero");
@@ -760,17 +805,18 @@ int main () {
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);                   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is disabled");
@@ -779,17 +825,18 @@ int main () {
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);            // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != 0));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is Enabled");
@@ -799,18 +846,19 @@ int main () {
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);                          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is disabled");
@@ -820,40 +868,70 @@ int main () {
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);            // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    FAIL_IF((intrpt != 1)); 
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((intrpt != 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
+#if ((STALL_BUF_DEPTH != 0) & (IMP_RRIDSCP))
     START_TEST("Stall MD Feature");
-    reset_iopmp();
+    // reset_iopmp();
     configure_srcmd_n(SRCMD_EN, 5, 0x10, 4);
     configure_srcmd_n(SRCMD_R, 5, 0x10, 4);
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
     write_register(MDSTALL_OFFSET, 0x10, 4);
     write_register(RRISCP_OFFSET,5,4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-    
+
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
     rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST(); 
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#elif ((STALL_BUF_DEPTH == 0) & (IMP_RRIDSCP))
+    // Set STALL_BUF_DEPTH zero to test this feature
+    START_TEST("Faulting Stalled Transactions Feature");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x10, 4);
+    configure_srcmd_n(SRCMD_EN, 5, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 5, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    set_hwcfg0_enable();
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, STALLED_TRANSACTION);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+#if (IOPMP_RRID_TRANSL_EN)
     START_TEST("Test Cascading IOPMP Feature");
     reset_iopmp();
     configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
@@ -862,38 +940,91 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | W | R), 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
 #if (MSI_EN)
-    START_TEST("Test MSI");
-    uint32_t read_data;
+
+    START_TEST("Test MSI Write error");
+    uint64_t read_data;
     reset_iopmp();
+    bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
-    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    read_memory(0x8000, 4, (char *)&read_data);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    bus_error = 0;
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data == 0x8F); // Interrupt is not suppressed
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MSI");
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    set_hwcfg0_enable();
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    read_memory(0x8000, 4, &read_data);
     FAIL_IF(intrpt == 1);
     FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+
+#endif
 #endif
     free(memory);
 
+#if (SRC_ENFORCEMENT_EN)
+    START_TEST("Test SourceEnforcement Enable Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 0, 0x02, 4);
+    configure_srcmd_n(SRCMD_R, 0, 0x02, 4);
+    configure_srcmd_n(SRCMD_W, 0, 0x02, 4);
+    configure_mdcfg_n(0, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 0, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 0, (NAPOT | W | R), 4);
+    set_hwcfg0_enable();
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+
+    receiver_port(12, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
     return 0;
 }

--- a/iopmp_ref_model/verif/tests/fullmodel.c
+++ b/iopmp_ref_model/verif/tests/fullmodel.c
@@ -1,0 +1,899 @@
+/***************************************************************************
+// Author:  Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the tests that are used to test
+// full model.
+// Max Supported RRIDs: 65536
+// Max Supported MDs: 63
+***************************************************************************/
+
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+// Declarations
+// Register offset to size mapping
+uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
+int test_num;
+iopmp_trans_req_t iopmp_trans_req;
+iopmp_trans_rsp_t iopmp_trans_rsp;
+err_reqinfo_t err_req_info_temp;
+int8_t *memory;
+uint64_t bus_error;
+
+int main () {
+    uint8_t intrpt;
+
+    FAIL_IF(create_memory(1) < 0)
+
+    START_TEST("Test OFF - Read Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (OFF | R), 4);
+    receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Write Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (OFF | R), 4);
+    receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Instruction Fetch permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (OFF | R), 4);
+    receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - UNKNOWN RRID ERROR");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (OFF | R), 4);
+    receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - Partial hit on a priority rule error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4); // SRCMD_R[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);           // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4); // SRCMD_R[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);           // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access with SRCMD_R not set");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);           // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+#if (IOPMP_SPS_EN == 0)
+    START_TEST("Test TOR - 4Byte Read Access, SRCMD_R not set, SPS disabled");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);                   // SRCMD_EN[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);                       // MDCFG[3].t contains 2
+    write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFFFFFFDF, 4);   // Disabling SPS extension
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);             // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, (TOR | R), 4);              // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);        // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);  // SRCMD_R[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4); // SRCMD_W[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);            // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, (TOR | W | R), 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);        // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);  // SRCMD_R[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4); // SRCMD_W[2] is associated with MD[3]
+    configure_mdcfg_n(3, 2, 4);            // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, 368 >> 2, 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, (TOR | W), 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4 | R), 4);
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Read Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4), 4);
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No SPS Read Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x00, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4 | R), 4);
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4 | W | R), 4);
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Write Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4 | R), 4);
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No SPS Write Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x00, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4 | W | R), 4);
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4 | X | W | R), 4);
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4 | W | R), 4);
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No SPS.R, Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x00, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4 | X | W | R), 4);
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 8Byte Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4 | R), 4);
+    receiver_port(32, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - For exact 4 Byte error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 364 >> 2, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NA4 | R), 4);
+    receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT), 4);
+    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT), 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | W | R), 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT), 4);
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 31, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 31, 0x10, 4);
+    configure_mdcfg_n(3, 17, 4);
+    configure_entry_n(ENTRY_ADDR, 1,  74, 4);    // (300 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    
+    configure_srcmd_n(SRCMD_EN, 32, 0x20, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x20, 4);
+    configure_mdcfg_n(4, 25, 4);
+    configure_entry_n(ENTRY_ADDR, 18,  90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 18, (NAPOT), 4);
+
+    configure_entry_n(ENTRY_ADDR, 20,  90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 20, (NAPOT | X), 4);
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating locked srcmd_en field");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x10, 4);
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating unlocked srcmd_en field");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x8, 4);
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDCFG_LCK, updating locked MDCFG field");
+    reset_iopmp();
+    write_register(MDCFGLCK_OFFSET,   0x8, 4);   // MD[0]-MD[3] are locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDCFG_LCK, updating unlocked MDCFG field");
+    reset_iopmp();
+    write_register(MDCFGLCK_OFFSET,   0x4, 4);   // MD[0]-MD[1] are locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating locked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 5, 4);
+    configure_entry_n(ENTRY_ADDR, 4,  90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 4, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test SRCMD_EN lock bit, updating locked SRCMD Table");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x1, 4);   // SRCMD_EN[2] lock bit is set
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test SRCMD_EN lock bit, updating unlocked SRCMD Table");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 1, 0x1, 4);   // SRCMD_EN[1] lock bit is set
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 5, 4);
+    configure_entry_n(ENTRY_ADDR, 4,  90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 4, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK register lock bit");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x8, 4);          // MD[2] is locked
+    write_register(MDLCK_OFFSET,   0x1, 4);          // Locking MDLCK register
+    write_register(MDLCK_OFFSET,   0x10, 4);         // Trying to lock MD[3] but it shouldn't be locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+
+    START_TEST("Test MDCFG_LCK register lock bit");
+    reset_iopmp();
+    write_register(MDCFGLCK_OFFSET,   0x8, 4);   // MD[0]-MD[3] are locked
+    write_register(MDCFGLCK_OFFSET,   0x1, 4);   // MDCFGLCK is locked
+    write_register(MDCFGLCK_OFFSET,   0x4, 4);   // Updating locked MD's MD[0]-MD[1] are locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK register lock bit");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    END_TEST();
+
+
+    START_TEST("Test MFR Extension");
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    err_mfr_t err_mfr_temp;
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svw != 0));
+    FAIL_IF((err_mfr_temp.svs != 0));
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svs != 1));
+    FAIL_IF((err_mfr_temp.svw != 1));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating locked srcmd_enh field");
+    reset_iopmp();
+    write_register(MDLCKH_OFFSET,   0x1, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating unlocked srcmd_enh field");
+    reset_iopmp();
+    write_register(MDLCKH_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST(); 
+
+    START_TEST("Test Interrupt Suppression is Enabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt Suppression is disabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+
+    START_TEST("Test Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x4, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is Enabled but rs is zero");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != 0));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x6, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt != 1)); 
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+
+    START_TEST("Stall MD Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 5, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 5, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | X), 4);
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST(); 
+
+    START_TEST("Test Cascading IOPMP Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | W | R), 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+#if (MSI_EN)
+    START_TEST("Test MSI");
+    uint32_t read_data;
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    read_memory(0x8000, 4, (char *)&read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+    free(memory);
+
+    return 0;
+}

--- a/iopmp_ref_model/verif/tests/isolationmodel.c
+++ b/iopmp_ref_model/verif/tests/isolationmodel.c
@@ -1,0 +1,649 @@
+/***************************************************************************
+// Author:  Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the tests that are used to test
+// Isolation model.
+// Max Supported RRIDs: 63
+// Max Supported MDs: 63
+// There is no physical SRCMD table. Instead, RRID i directly maps to MD i.
+// Associated IOPMP entries are extracted from MD i and traversed for 
+// address matching and permission checks.
+***************************************************************************/
+
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+// Declarations
+// Register offset to size mapping
+uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
+int test_num;
+iopmp_trans_req_t iopmp_trans_req;
+iopmp_trans_rsp_t iopmp_trans_rsp;
+err_reqinfo_t err_req_info_temp;
+int8_t *memory;
+uint64_t bus_error;
+
+int main () {
+
+    uint8_t intrpt;
+
+    FAIL_IF(create_memory(1) < 0)
+
+    START_TEST("Test OFF - Read Access permissions");
+    reset_iopmp();
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Write Access permissions");
+    reset_iopmp();
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Instruction Fetch permissions");
+    reset_iopmp();
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - UNKNOWN RRID ERROR");
+    reset_iopmp();
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - Partial hit on a priority rule error");
+    reset_iopmp();
+    configure_mdcfg_n(2, 2, 4);           // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0x09, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access");
+    reset_iopmp();
+    configure_mdcfg_n(2, 2, 4);           // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0x09, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0xB, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0xA, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Read Access");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Read Access error");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x10, 4);
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Write Access");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Write Access error");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+
+    START_TEST("Test NA4 - 4Byte Execute Access");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x17, 4);
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Execute Access");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+
+    START_TEST("Test NA4 - 8Byte Access error");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(32, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - For exact 4 Byte error");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x19, 4);
+    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access error");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access error");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access error");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    // START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
+    // // Receiver Port Signals
+    // reset_iopmp();
+    // configure_mdcfg_n(3, 17, 4);
+    // configure_entry_n(ENTRY_ADDR, 1, 74, 4);    // (300 >> 2) and keeping lsb 0
+    // configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    // configure_mdcfg_n(4, 25, 4);
+    // configure_entry_n(ENTRY_ADDR, 18, 90, 4);    // (364 >> 2) and keeping lsb 0
+    // configure_entry_n(ENTRY_CFG, 18, 0x18, 4);
+
+    // configure_entry_n(ENTRY_ADDR, 20, 90, 4);    // (364 >> 2) and keeping lsb 0
+    // configure_entry_n(ENTRY_CFG, 20, 0x1C, 4);
+    // iopmp_trans_req.rrid     = 32;
+    // iopmp_trans_req.addr     = 360;
+    // iopmp_trans_req.length   = 0;
+    // iopmp_trans_req.size     = 3;
+    // iopmp_trans_req.perm     = INSTR_FETCH;
+
+    // // requestor Port Signals
+    // iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    // CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    // write_register(ERR_REQINFO_OFFSET,   0, 4);
+    // END_TEST();
+
+    START_TEST("Test MDCFG_LCK, updating locked MDCFG field");
+    reset_iopmp();
+    write_register(MDCFGLCK_OFFSET,   0x8, 4);   // MD[0]-MD[3] are locked
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDCFG_LCK, updating unlocked MDCFG field");
+    reset_iopmp();
+    write_register(MDCFGLCK_OFFSET,   0x4, 4);   // MD[0]-MD[1] are locked
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating locked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_mdcfg_n(2, 5, 4);
+    configure_entry_n(ENTRY_ADDR, 4, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 4, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK register lock bit");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x8, 4);          // MD[2] is locked
+    write_register(MDLCK_OFFSET,   0x1, 4);          // Locking MDLCK register
+    write_register(MDLCK_OFFSET,   0x10, 4);         // Trying to lock MD[3] but it shouldn't be locked
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+
+    START_TEST("Test MDCFG_LCK register lock bit");
+    reset_iopmp();
+    write_register(MDCFGLCK_OFFSET,   0x8, 4);   // MD[0]-MD[3] are locked
+    write_register(MDCFGLCK_OFFSET,   0x1, 4);   // MDCFGLCK is locked
+    write_register(MDCFGLCK_OFFSET,   0x4, 4);   // Updating locked MD's MD[0]-MD[1] are locked
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK register lock bit");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    END_TEST();
+
+
+    START_TEST("Test MFR Extension");
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    err_mfr_t err_mfr_temp;
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svw != 0));
+    FAIL_IF((err_mfr_temp.svs != 0));
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svs != 1));
+    FAIL_IF((err_mfr_temp.svw != 1));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+    
+    START_TEST("Test Interrupt Suppression is Enabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt Suppression is disabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+
+    START_TEST("Test Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x4, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is Enabled but rs is zero");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != 0));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x6, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt != 1)); 
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+
+    START_TEST("Stall MD Feature");
+    reset_iopmp();
+    configure_mdcfg_n(5, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    write_register(MDSTALL_OFFSET, 0x40, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST(); 
+
+    START_TEST("Test Cascading IOPMP Feature");
+    reset_iopmp();
+    configure_mdcfg_n(32, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+#if (MSI_EN)
+    START_TEST("Test MSI");
+    uint32_t read_data;
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    read_memory(0x8000, 4, (char *)&read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+    
+    free(memory);
+
+    return 0;
+}

--- a/iopmp_ref_model/verif/tests/isolationmodel.c
+++ b/iopmp_ref_model/verif/tests/isolationmodel.c
@@ -6,7 +6,7 @@
 // Max Supported RRIDs: 63
 // Max Supported MDs: 63
 // There is no physical SRCMD table. Instead, RRID i directly maps to MD i.
-// Associated IOPMP entries are extracted from MD i and traversed for 
+// Associated IOPMP entries are extracted from MD i and traversed for
 // address matching and permission checks.
 ***************************************************************************/
 
@@ -15,14 +15,9 @@
 #include "test_utils.h"
 
 // Declarations
-// Register offset to size mapping
-uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
-int test_num;
 iopmp_trans_req_t iopmp_trans_req;
 iopmp_trans_rsp_t iopmp_trans_rsp;
-err_reqinfo_t err_req_info_temp;
-int8_t *memory;
-uint64_t bus_error;
+err_info_t err_info_temp;
 
 int main () {
 
@@ -30,17 +25,20 @@ int main () {
 
     FAIL_IF(create_memory(1) < 0)
 
+#if (SRC_ENFORCEMENT_EN == 0)
+
     START_TEST("Test OFF - Read Access permissions");
     reset_iopmp();
     configure_mdcfg_n(2, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Write Access permissions");
@@ -48,12 +46,13 @@ int main () {
     configure_mdcfg_n(2, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Instruction Fetch permissions");
@@ -61,12 +60,13 @@ int main () {
     configure_mdcfg_n(2, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - UNKNOWN RRID ERROR");
@@ -74,77 +74,85 @@ int main () {
     configure_mdcfg_n(2, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
+#if (IOPMP_TOR_EN)
     START_TEST("Test TOR - Partial hit on a priority rule error");
     reset_iopmp();
     configure_mdcfg_n(2, 2, 4);           // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0x09, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x09, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Read Access");
     reset_iopmp();
     configure_mdcfg_n(2, 2, 4);           // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0x09, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x09, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
-    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_mdcfg_n(2, 2, 4);                // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0xB, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
-    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_mdcfg_n(2, 2, 4);                // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR,1, (368 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0xA, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test NA4 - 4Byte Read Access");
     reset_iopmp();
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Read Access error");
@@ -152,12 +160,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x10, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Write Access");
@@ -165,12 +174,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Write Access error");
@@ -178,12 +188,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
 
@@ -192,12 +203,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x17, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Execute Access");
@@ -205,12 +217,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
 
@@ -219,12 +232,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - For exact 4 Byte error");
@@ -232,12 +246,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access");
@@ -245,12 +260,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x19, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access error");
@@ -258,12 +274,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access error");
@@ -271,12 +288,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access");
@@ -284,12 +302,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access error");
@@ -297,12 +316,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access");
@@ -310,12 +330,13 @@ int main () {
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     // START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
@@ -324,12 +345,15 @@ int main () {
     // configure_mdcfg_n(3, 17, 4);
     // configure_entry_n(ENTRY_ADDR, 1, 74, 4);    // (300 >> 2) and keeping lsb 0
     // configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     // configure_mdcfg_n(4, 25, 4);
     // configure_entry_n(ENTRY_ADDR, 18, 90, 4);    // (364 >> 2) and keeping lsb 0
     // configure_entry_n(ENTRY_CFG, 18, 0x18, 4);
+    set_hwcfg0_enable();
 
     // configure_entry_n(ENTRY_ADDR, 20, 90, 4);    // (364 >> 2) and keeping lsb 0
     // configure_entry_n(ENTRY_CFG, 20, 0x1C, 4);
+    set_hwcfg0_enable();
     // iopmp_trans_req.rrid     = 32;
     // iopmp_trans_req.addr     = 360;
     // iopmp_trans_req.length   = 0;
@@ -337,65 +361,69 @@ int main () {
     // iopmp_trans_req.perm     = INSTR_FETCH;
 
     // // requestor Port Signals
-    // iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    // iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     // CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    // write_register(ERR_REQINFO_OFFSET,   0, 4);
+    // write_register(ERR_INFO_OFFSET,   0, 4);
     // END_TEST();
 
     START_TEST("Test MDCFG_LCK, updating locked MDCFG field");
     reset_iopmp();
     write_register(MDCFGLCK_OFFSET,   0x8, 4);   // MD[0]-MD[3] are locked
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);      // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDCFG_LCK, updating unlocked MDCFG field");
     reset_iopmp();
     write_register(MDCFGLCK_OFFSET,   0x4, 4);   // MD[0]-MD[1] are locked
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);      // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating locked ENTRY field");
     reset_iopmp();
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);      // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
     reset_iopmp();
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     configure_mdcfg_n(2, 5, 4);
-    configure_entry_n(ENTRY_ADDR, 4, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 4, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 4, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK register lock bit");
@@ -404,14 +432,15 @@ int main () {
     write_register(MDLCK_OFFSET,   0x1, 4);          // Locking MDLCK register
     write_register(MDLCK_OFFSET,   0x10, 4);         // Trying to lock MD[3] but it shouldn't be locked
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
 
@@ -421,14 +450,15 @@ int main () {
     write_register(MDCFGLCK_OFFSET,   0x1, 4);   // MDCFGLCK is locked
     write_register(MDCFGLCK_OFFSET,   0x4, 4);   // Updating locked MD's MD[0]-MD[1] are locked
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);      // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK register lock bit");
@@ -437,12 +467,13 @@ int main () {
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
     write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);      // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
@@ -452,8 +483,9 @@ int main () {
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
     write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR,1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR,1, 90, 4);      // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
@@ -461,28 +493,29 @@ int main () {
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
     FAIL_IF((err_mfr_temp.svw != 0));
     FAIL_IF((err_mfr_temp.svs != 0));
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
-    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svi != 0));
     FAIL_IF((err_mfr_temp.svs != 1));
-    FAIL_IF((err_mfr_temp.svw != 1));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
-    
+    FAIL_IF((err_mfr_temp.svw != 4));
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+
     START_TEST("Test Interrupt Suppression is Enabled");
     reset_iopmp();
     write_register(ERR_OFFSET,   0x2, 4);
     configure_mdcfg_n(2, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
-    configure_entry_n(ENTRY_CFG, 1, 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    configure_entry_n(ENTRY_CFG, 1, 0x99, 4);  // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1)); // Interrupt is suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt Suppression is disabled");
@@ -491,65 +524,69 @@ int main () {
     configure_mdcfg_n(2, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
     START_TEST("Test Error Suppression is Enabled");
     // Receiver Port Signals
     reset_iopmp();
     write_register(ERR_OFFSET,   0x4, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);               // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is Enabled but rs is zero");
     // Receiver Port Signals
     reset_iopmp();
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);               // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is disabled");
     // Receiver Port Signals
     reset_iopmp();
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != 0));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is Enabled");
@@ -557,18 +594,19 @@ int main () {
     reset_iopmp();
     write_register(ERR_OFFSET,   0x6, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);                          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is disabled");
@@ -576,74 +614,149 @@ int main () {
     reset_iopmp();
     write_register(ERR_OFFSET,   0x2, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);            // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    FAIL_IF((intrpt != 1)); 
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((intrpt != 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
+#if ((STALL_BUF_DEPTH != 0) & (IMP_RRIDSCP))
     START_TEST("Stall MD Feature");
     reset_iopmp();
     configure_mdcfg_n(5, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     write_register(MDSTALL_OFFSET, 0x40, 4);
     write_register(RRISCP_OFFSET,5,4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-    
+
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
     rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST(); 
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#elif (IMP_RRIDSCP)
+    // Set STALL_BUF_DEPTH zero to test this feature
+    START_TEST("Faulting Stalled Transactions Feature");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x10, 4);
+     configure_mdcfg_n(5, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
+    write_register(MDSTALL_OFFSET, 0x40, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, STALLED_TRANSACTION);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+#if (IOPMP_RRID_TRANSL_EN)
     START_TEST("Test Cascading IOPMP Feature");
     reset_iopmp();
     configure_mdcfg_n(32, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    set_hwcfg0_enable();
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
 #if (MSI_EN)
-    START_TEST("Test MSI");
-    uint32_t read_data;
+    START_TEST("Test MSI Write error");
+    uint64_t read_data;
     reset_iopmp();
+    bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
-    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
     configure_mdcfg_n(2, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
-    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    read_memory(0x8000, 4, (char *)&read_data);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    bus_error = 0;
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data == 0x8F); // Interrupt is not suppressed
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MSI");
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    set_hwcfg0_enable();
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    read_memory(0x8000, 4, &read_data);
     FAIL_IF(intrpt == 1);
     FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 #endif
-    
+#endif
+
     free(memory);
+
+#if (SRC_ENFORCEMENT_EN)
+    START_TEST("Test SourceEnforcement Enable Feature");
+    reset_iopmp();
+    configure_mdcfg_n(0, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 0, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 0, (NAPOT | W | R), 4);
+    set_hwcfg0_enable();
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+
+    receiver_port(12, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
 
     return 0;
 }

--- a/iopmp_ref_model/verif/tests/rapidmodel.c
+++ b/iopmp_ref_model/verif/tests/rapidmodel.c
@@ -1,0 +1,863 @@
+/***************************************************************************
+// Author: Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the tests that are used to test
+// rapid-k model.
+// Max Supported RRIDs: 65536
+// Max Supported MDs: 63
+// Uses the RRID to obtain SRCMD_EN(H), indicating the associated MDs.
+// There is no physical MDCFG table in this model. Each MD has k associated 
+// IOPMP entries. IOPMP entries linked to the MD associated with
+// the RRID are traversed for address matching and permission checks.
+// IOPMP Entry Ranges for Each MD:
+// MD0 → 0 to (k - 1)
+// MD1 → k to (2k - 1)
+// MD2 → 2k to (3k - 1), and so on.
+***************************************************************************/
+
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+// Declarations
+// Register offset to size mapping
+uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
+int test_num;
+iopmp_trans_req_t iopmp_trans_req;
+iopmp_trans_rsp_t iopmp_trans_rsp;
+err_reqinfo_t err_req_info_temp;
+int8_t *memory;
+uint64_t bus_error;
+
+int main () {
+
+    uint8_t intrpt;
+
+    FAIL_IF(create_memory(1) < 0)
+
+    START_TEST("Test OFF - Read Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Write Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Instruction Fetch permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - UNKNOWN RRID ERROR");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x01, 4);
+    receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - Partial hit on a priority rule error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4); // SRCMD_R[2] is associated with MD[3]
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x09, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4); // SRCMD_R[2] is associated with MD[3]
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x09, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access with SRCMD_R not set");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);       // SRCMD_EN[2] is associated with MD[3]
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x09, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+#if (IOPMP_SPS_EN == 0)
+    START_TEST("Test TOR - 4Byte Read Access, SRCMD_R not set, SPS disabled");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);                   // SRCMD_EN[2] is associated with MD[3]
+    // Entry Table CFG
+    write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFFFFFFDF, 4);   // Disabling SPS extension
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x09, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);        // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);  // SRCMD_R[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4); // SRCMD_W[2] is associated with MD[3]
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x0B, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);        // SRCMD_EN[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);  // SRCMD_R[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_W, 2, 0x10, 4); // SRCMD_W[2] is associated with MD[3]
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0xA, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Read Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x10, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No SPS Read Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x00, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Write Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No SPS Write Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x00, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x17, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x13, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No SPS.R, Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x00, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x17, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 8Byte Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(32, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - For exact 4 Byte error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x11, 4);
+    receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x19, 4);
+    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x18, 4);
+    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x18, 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1B, 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x18, 4);
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 31, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 31, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 74, 4);    // (300 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+
+    configure_srcmd_n(SRCMD_EN, 32, 0x20, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x20, 4);
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 4), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 4), 0x18, 4);
+
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 4), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 4), 0x1C, 4);
+    iopmp_trans_req.rrid     = 32;
+    iopmp_trans_req.addr     = 360;
+    iopmp_trans_req.length   = 0;
+    iopmp_trans_req.size     = 3;
+    iopmp_trans_req.perm     = INSTR_FETCH;
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating locked srcmd_en field");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x10, 4);
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating unlocked srcmd_en field");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x8, 4);
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating locked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test SRCMD_EN lock bit, updating locked SRCMD Table");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 2, 0x1, 4);   // SRCMD_EN[2] lock bit is set
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test SRCMD_EN lock bit, updating unlocked SRCMD Table");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1, 4);   // SRCMD_EN[1] lock bit is set
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    write_register(MDCFG_TABLE_BASE_OFFSET + (3 * 4),   5, 4);
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK register lock bit");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x8, 4);          // MD[2] is locked
+    write_register(MDLCK_OFFSET,   0x1, 4);          // Locking MDLCK register
+    write_register(MDLCK_OFFSET,   0x10, 4);         // Trying to lock MD[3] but it shouldn't be locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK register lock bit");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    END_TEST();
+
+
+    START_TEST("Test MFR Extension");
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_EN, 2, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 2, 0x10, 4);
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR,((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG,((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    err_mfr_t err_mfr_temp;
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svw != 0));
+    FAIL_IF((err_mfr_temp.svs != 0));
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svs != 1));
+    FAIL_IF((err_mfr_temp.svw != 1));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating locked srcmd_enh field");
+    reset_iopmp();
+    write_register(MDLCKH_OFFSET,   0x1, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK, updating unlocked srcmd_enh field");
+    reset_iopmp();
+    write_register(MDLCKH_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt Suppression is Enabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt Suppression is disabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT|R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x4, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is Enabled but rs is zero");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != 0));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x6, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt != 1)); 
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Stall MD Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 5, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 5, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1C, 4);
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Cascading IOPMP Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_EN, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_R, 32, 0x10, 4);
+    configure_srcmd_n(SRCMD_W, 32, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 3), 0x1B, 4);
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+#if (MSI_EN)
+    START_TEST("Test MSI");
+    uint32_t read_data;
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
+    configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);
+    configure_entry_n(ENTRY_CFG, ((IOPMP_MD_ENTRY_NUM + 1) * 31), (NAPOT | R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    read_memory(0x8000, 4, (char *)&read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+    free(memory);
+
+    return 0;
+}

--- a/iopmp_ref_model/verif/tests/unnamed_model_1.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_1.c
@@ -16,168 +16,177 @@
 #include "test_utils.h"
 
 // Declarations
-// Register offset to size mapping
-uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
-int test_num;
 iopmp_trans_req_t iopmp_trans_req;
 iopmp_trans_rsp_t iopmp_trans_rsp;
-err_reqinfo_t err_req_info_temp;
-int8_t *memory;
-uint64_t bus_error;
+err_info_t err_info_temp;
 
 int main () {
     uint8_t intrpt;
 
     FAIL_IF(create_memory(1) < 0)
-    
+
+#if (SRC_ENFORCEMENT_EN == 0)
+
     START_TEST("Test OFF - Read Access permissions");
     reset_iopmp();
     receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Write Access permissions");
     reset_iopmp();
     receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF|R), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Instruction Fetch permissions");
     reset_iopmp();
     receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - UNKNOWN RRID ERROR");
     reset_iopmp();
     receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
+#if (IOPMP_TOR_EN)
     START_TEST("Test TOR - Partial hit on a priority rule error");
     reset_iopmp();
     receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Read Access");
     reset_iopmp();
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
     write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
-      
+
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W|R), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Only Write Access");
     reset_iopmp();
-         
+
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test NA4 - 4Byte Read Access");
     reset_iopmp();
-        
+
     receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);
+    set_hwcfg0_enable();
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Read Access error");
     reset_iopmp();
-         
+
     receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Write Access");
@@ -186,14 +195,15 @@ int main () {
 
     receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Write Access error");
@@ -202,14 +212,15 @@ int main () {
 
     receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Execute Access");
@@ -218,14 +229,15 @@ int main () {
 
     receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|X|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|X|W|R), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Execute Access");
@@ -234,14 +246,15 @@ int main () {
 
     receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
-    // Entry Table CFG  
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 8Byte Access error");
@@ -250,14 +263,15 @@ int main () {
 
     receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - For exact 4 Byte error");
@@ -266,47 +280,50 @@ int main () {
 
     receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access");
     // Reset IOPMP
     reset_iopmp();
-    
+
     receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|R), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access error");
     // Reset IOPMP
     reset_iopmp();
-    
+
     receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access error");
@@ -315,61 +332,65 @@ int main () {
 
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access");
     // Reset IOPMP
     reset_iopmp();
-   
+
     receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
-    // Entry Table CFG 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W|R), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access error");
     reset_iopmp();
     receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-    // Entry Table CFG 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access");
     // Reset
     reset_iopmp();
     receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-    // Entry Table CFG 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // Entry Table CFG
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
@@ -377,19 +398,22 @@ int main () {
     reset_iopmp();
     receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 74, 4);  // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 74, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);
+    set_hwcfg0_enable();
 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x18, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x18, 4);
+    set_hwcfg0_enable();
 
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating locked ENTRY field");
@@ -398,32 +422,34 @@ int main () {
 
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-    // Entry Table CFG 
+    // Entry Table CFG
     write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
-    
+
     reset_iopmp();
 
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-    // Entry Table CFG 
+    // Entry Table CFG
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[15] are locked
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK register lock bit");
@@ -431,26 +457,28 @@ int main () {
     reset_iopmp();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-    // Entry Table CFG 
+    // Entry Table CFG
     write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
-    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
-    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);      // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);      // ENTRY[0] is locked
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);
+    set_hwcfg0_enable();
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
     START_TEST("Test MFR Extension");
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-    // Entry Table CFG 
+    // Entry Table CFG
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
     write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
-    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);
+    set_hwcfg0_enable();
 
 
     // requestor Port Signals
@@ -458,28 +486,29 @@ int main () {
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
     FAIL_IF((err_mfr_temp.svw != 0));
     FAIL_IF((err_mfr_temp.svs != 0));
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
-    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svi != 0));
     FAIL_IF((err_mfr_temp.svs != 1));
-    FAIL_IF((err_mfr_temp.svw != 1));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();    
+    FAIL_IF((err_mfr_temp.svw != 4));
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
     START_TEST("Test Interrupt Suppression is Enabled");
    reset_iopmp();
    write_register(ERR_OFFSET,   0x2, 4);
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);     // (364 >> 2) and keeping lsb 0
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+    set_hwcfg0_enable();
+
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Interrupt Suppression is disabled");
@@ -488,65 +517,69 @@ int main () {
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
-   
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
-   END_TEST();   
+   write_register(ERR_INFO_OFFSET,   0, 4);
+   END_TEST();
 
    START_TEST("Test Error Suppression is Enabled");
    // Receiver Port Signals
    reset_iopmp();
    write_register(ERR_OFFSET,   0x4, 4);
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);               // (364 >> 2) and keeping lsb 0
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
    FAIL_IF((iopmp_trans_rsp.rrid != 2));
    FAIL_IF((iopmp_trans_rsp.user != USER));
    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Error Suppression is Enabled but rs is zero");
    // Receiver Port Signals
    reset_iopmp();
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);               // (364 >> 2) and keeping lsb 0
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
    FAIL_IF((iopmp_trans_rsp.rrid != 2));
    FAIL_IF((iopmp_trans_rsp.user != USER));
    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Error Suppression is disabled");
    // Receiver Port Signals
    reset_iopmp();
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);          // (364 >> 2) and keeping lsb 0
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
    FAIL_IF((iopmp_trans_rsp.rrid != 2));
    FAIL_IF((iopmp_trans_rsp.user != 0));
    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Interrupt and Error Suppression is Enabled");
@@ -554,18 +587,19 @@ int main () {
    reset_iopmp();
    write_register(ERR_OFFSET,   0x6, 4);
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);                          // (364 >> 2) and keeping lsb 0
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((intrpt == 1));
    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
    FAIL_IF((iopmp_trans_rsp.rrid != 2));
    FAIL_IF((iopmp_trans_rsp.user != USER));
    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
 
    START_TEST("Test Interrupt and Error Suppression is disabled");
@@ -573,53 +607,142 @@ int main () {
    reset_iopmp();
    write_register(ERR_OFFSET,   0x2, 4);
    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);            // (364 >> 2) and keeping lsb 0
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
-   
+    set_hwcfg0_enable();
+
 
    // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-   FAIL_IF((intrpt != 1)); 
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+   FAIL_IF((intrpt != 1));
    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
    FAIL_IF((iopmp_trans_rsp.rrid != 2));
    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
-   END_TEST();   
+   write_register(ERR_INFO_OFFSET,   0, 4);
+   END_TEST();
 
+#if (IOPMP_RRID_TRANSL_EN)
    START_TEST("Test Cascading IOPMP Feature");
    reset_iopmp();
    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 0x1B, 4);
+    set_hwcfg0_enable();
 
    // requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
    FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
+#endif
+#endif
 
 #if (MSI_EN)
-   START_TEST("Test MSI");
-   uint32_t read_data;
-   reset_iopmp();
-   write_register(ERR_OFFSET, 0x8F0A, 4);
-   write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
-   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
-   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
+    START_TEST("Test MSI Write error");
+    uint64_t read_data;
+    reset_iopmp();
+    bus_error = 0x8000;
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
+    set_hwcfg0_enable();
 
-   // Requestor Port Signals
-   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-   read_memory(0x8000, 4, (char *)&read_data);
-   FAIL_IF(intrpt == 1);
-   FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
-   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-   write_register(ERR_REQINFO_OFFSET,   0, 4);
-   END_TEST();
+    // Requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    bus_error = 0;
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data == 0x8F); // Interrupt is not suppressed
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MSI");
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
+    set_hwcfg0_enable();
+
+    // Requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 #endif
    free(memory);
 
+#if (SRC_ENFORCEMENT_EN)
+    START_TEST("Test SourceEnforcement Enable Feature");
+    reset_iopmp();
+    configure_entry_n(ENTRY_ADDR, 0, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 0, (NAPOT | W | R), 4);
+    set_hwcfg0_enable();
+
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+
+    receiver_port(12, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+#if ((STALL_BUF_DEPTH != 0) & (IMP_RRIDSCP))
+    START_TEST("Stall MD Feature");
+    // reset_iopmp();
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT | X), 4);
+    set_hwcfg0_enable();
+    write_register(MDSTALL_OFFSET, 0x40, 4);
+    write_register(RRISCP_OFFSET,5,4);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#elif (IMP_RRIDSCP)
+    // Set STALL_BUF_DEPTH zero to test this feature
+    START_TEST("Faulting Stalled Transactions Feature");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x10, 4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT | X), 4);
+    set_hwcfg0_enable();
+    write_register(MDSTALL_OFFSET, 0x40, 4);
+    write_register(RRISCP_OFFSET,5,4);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, STALLED_TRANSACTION);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
 
     return 0;
 }

--- a/iopmp_ref_model/verif/tests/unnamed_model_1.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_1.c
@@ -1,0 +1,625 @@
+/***************************************************************************
+// Author: Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the tests that are used to test
+// unamed1 model.
+// Max Supported RRIDs: 63
+// Max Supported MDs: 63
+// There is no physical SRCMD table. RRID i directly maps to MD i.
+// There is no physical MDCFG table. Each MD has k associated IOPMP entries.
+// Value of k is programmable. Associated IOPMP Entry Ranges:
+// (i × k) to ((i + 1) × k - 1) for address matching and permission checks.
+***************************************************************************/
+
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+// Declarations
+// Register offset to size mapping
+uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
+int test_num;
+iopmp_trans_req_t iopmp_trans_req;
+iopmp_trans_rsp_t iopmp_trans_rsp;
+err_reqinfo_t err_req_info_temp;
+int8_t *memory;
+uint64_t bus_error;
+
+int main () {
+    uint8_t intrpt;
+
+    FAIL_IF(create_memory(1) < 0)
+    
+    START_TEST("Test OFF - Read Access permissions");
+    reset_iopmp();
+    receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Write Access permissions");
+    reset_iopmp();
+    receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Instruction Fetch permissions");
+    reset_iopmp();
+    receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - UNKNOWN RRID ERROR");
+    reset_iopmp();
+    receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (OFF), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - Partial hit on a priority rule error");
+    reset_iopmp();
+    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access");
+    reset_iopmp();
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
+      
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Only Write Access");
+    reset_iopmp();
+         
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (TOR|W), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Read Access");
+    reset_iopmp();
+        
+    receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Read Access error");
+    reset_iopmp();
+         
+    receiver_port(32, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Write Access");
+    // Reset IOPMP
+    reset_iopmp();
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Write Access error");
+    // Reset
+    reset_iopmp();
+
+    receiver_port(32, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Execute Access");
+    // Reset IOPMP
+    reset_iopmp();
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|X|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Execute Access");
+    // Reset IOPMP
+    reset_iopmp();
+
+    receiver_port(32, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // Entry Table CFG  
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 8Byte Access error");
+    // Reset
+    reset_iopmp();
+
+    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG 
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - For exact 4 Byte error");
+    // Reset
+    reset_iopmp();
+
+    receiver_port(32, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG 
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (364 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NA4|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access");
+    // Reset IOPMP
+    reset_iopmp();
+    
+    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG 
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access error");
+    // Reset IOPMP
+    reset_iopmp();
+    
+    receiver_port(32, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG 
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access error");
+    // Reset IOPMP
+    reset_iopmp();
+
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG 
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access");
+    // Reset IOPMP
+    reset_iopmp();
+   
+    receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // Entry Table CFG 
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|W|R), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access error");
+    reset_iopmp();
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Entry Table CFG 
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access");
+    // Reset
+    reset_iopmp();
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    // Entry Table CFG 
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
+    // Receiver Port Signals
+    reset_iopmp();
+    receiver_port(32, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 74, 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x18, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 0x1C, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating locked ENTRY field");
+    // Reset IOPMP
+    reset_iopmp();
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Entry Table CFG 
+    write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
+    
+    reset_iopmp();
+
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Entry Table CFG 
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[15] are locked
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK register lock bit");
+
+    reset_iopmp();
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Entry Table CFG 
+    write_register(ENTRYLCK_OFFSET,   0x1000, 4);   // ENTRY[0]-ENTRY[15] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    END_TEST();
+
+    START_TEST("Test MFR Extension");
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    // Entry Table CFG 
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), 90, 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM+1)), (NAPOT|X), 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+
+
+    // requestor Port Signals
+    err_mfr_t err_mfr_temp;
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svw != 0));
+    FAIL_IF((err_mfr_temp.svs != 0));
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svs != 1));
+    FAIL_IF((err_mfr_temp.svw != 1));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();    
+
+    START_TEST("Test Interrupt Suppression is Enabled");
+   reset_iopmp();
+   write_register(ERR_OFFSET,   0x2, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Interrupt Suppression is disabled");
+   reset_iopmp();
+   write_register(ERR_OFFSET,   0x2, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();   
+
+   START_TEST("Test Error Suppression is Enabled");
+   // Receiver Port Signals
+   reset_iopmp();
+   write_register(ERR_OFFSET,   0x4, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+   FAIL_IF((iopmp_trans_rsp.rrid != 2));
+   FAIL_IF((iopmp_trans_rsp.user != USER));
+   error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Error Suppression is Enabled but rs is zero");
+   // Receiver Port Signals
+   reset_iopmp();
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+   FAIL_IF((iopmp_trans_rsp.rrid != 2));
+   FAIL_IF((iopmp_trans_rsp.user != USER));
+   error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Error Suppression is disabled");
+   // Receiver Port Signals
+   reset_iopmp();
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+   FAIL_IF((iopmp_trans_rsp.rrid != 2));
+   FAIL_IF((iopmp_trans_rsp.user != 0));
+   error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Interrupt and Error Suppression is Enabled");
+   // Receiver Port Signals
+   reset_iopmp();
+   write_register(ERR_OFFSET,   0x6, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((intrpt == 1));
+   FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+   FAIL_IF((iopmp_trans_rsp.rrid != 2));
+   FAIL_IF((iopmp_trans_rsp.user != USER));
+   error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+   START_TEST("Test Interrupt and Error Suppression is disabled");
+   // Receiver Port Signals
+   reset_iopmp();
+   write_register(ERR_OFFSET,   0x2, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+   
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((intrpt != 1)); 
+   FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+   FAIL_IF((iopmp_trans_rsp.rrid != 2));
+   error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();   
+
+   START_TEST("Test Cascading IOPMP Feature");
+   reset_iopmp();
+   receiver_port(32, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);   // (364 >> 2) and keeping lsb 0
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 0x1B, 4);
+
+   // requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
+   CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+
+#if (MSI_EN)
+   START_TEST("Test MSI");
+   uint32_t read_data;
+   reset_iopmp();
+   write_register(ERR_OFFSET, 0x8F0A, 4);
+   write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+   receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+   configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
+   configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
+
+   // Requestor Port Signals
+   iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+   read_memory(0x8000, 4, (char *)&read_data);
+   FAIL_IF(intrpt == 1);
+   FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+   CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+   write_register(ERR_REQINFO_OFFSET,   0, 4);
+   END_TEST();
+#endif
+   free(memory);
+
+
+    return 0;
+}

--- a/iopmp_ref_model/verif/tests/unnamed_model_2.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_2.c
@@ -1,0 +1,686 @@
+/***************************************************************************
+// Author:  Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the tests that are used to test
+// unamed2 model.
+// Max Supported RRIDs: 32
+// Max Supported MDs: 63
+// SRCMD_EN(H) and SPS extension registers are replaced with SRCMD_PERM(H).
+// All MDs are associated with the given RRID.
+// The MDCFG table is traversed for all MDs.
+// Associated IOPMP entries are extracted and traversed for address matching
+// and permission checks.
+***************************************************************************/
+
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+// Declarations
+// Register offset to size mapping
+uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
+int test_num;
+iopmp_trans_req_t iopmp_trans_req;
+iopmp_trans_rsp_t iopmp_trans_rsp;
+err_reqinfo_t err_req_info_temp;
+int8_t *memory;
+uint64_t bus_error;
+
+int main () {
+    uint8_t intrpt;
+
+    FAIL_IF(create_memory(1) < 0)
+    
+    START_TEST("Test OFF - Read Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x30, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Write Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Instruction Fetch permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - UNKNOWN RRID ERROR");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - Partial hit on a priority rule error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
+    configure_mdcfg_n(2, 2, 4);           // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
+    write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
+    configure_mdcfg_n(2, 2, 4);           // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0xB, 4);        // SRCMD_PERM[2] is associated with MD[3]
+    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0xB, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0xA, 4);        // SRCMD_PERM[2] is associated with MD[3]
+    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0xA, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Read Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x10, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x10, 4);
+    receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x13, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Write Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x17, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x17, 4);
+    receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x13, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 8Byte Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - For exact 4 Byte error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x19, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x19, 4);
+    receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x1B, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x1C, 4);
+    configure_mdcfg_n(30, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 29, 0x1C, 4);
+    configure_mdcfg_n(29, 17, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 74, 4);    // (300 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_mdcfg_n(30, 25, 4);
+    configure_entry_n(ENTRY_ADDR, 18, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 18, 0x18, 4);
+
+    configure_entry_n(ENTRY_ADDR, 20, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 20, 0x1C, 4);
+    receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDCFG_LCK, updating locked MDCFG field");
+    reset_iopmp();
+    write_register(MDCFGLCK_OFFSET,   0x8, 4);   // MD[0]-MD[3] are locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDCFG_LCK, updating unlocked MDCFG field");
+    reset_iopmp();
+    write_register(MDCFGLCK_OFFSET,   0x4, 4);   // MD[0]-MD[1] are locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating locked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_mdcfg_n(2, 5, 4);
+    configure_entry_n(ENTRY_ADDR, 4, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 4, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MDLCK register lock bit");
+    reset_iopmp();
+    write_register(MDLCK_OFFSET,   0x8, 4);          // MD[2] is locked
+    write_register(MDLCK_OFFSET,   0x1, 4);          // Locking MDLCK register
+    write_register(MDLCK_OFFSET,   0x10, 4);         // Trying to lock MD[3] but it shouldn't be locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+
+    START_TEST("Test MDCFG_LCK register lock bit");
+    reset_iopmp();
+    write_register(MDCFGLCK_OFFSET,   0x8, 4);   // MD[0]-MD[3] are locked
+    write_register(MDCFGLCK_OFFSET,   0x1, 4);   // MDCFGLCK is locked
+    write_register(MDCFGLCK_OFFSET,   0x4, 4);   // Updating locked MD's MD[0]-MD[1] are locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK register lock bit");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    END_TEST();
+
+
+    START_TEST("Test MFR Extension");
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    err_mfr_t err_mfr_temp;
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svw != 0));
+    FAIL_IF((err_mfr_temp.svs != 0));
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svs != 1));
+    FAIL_IF((err_mfr_temp.svw != 1));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();    
+
+    START_TEST("Test Interrupt Suppression is Enabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt Suppression is disabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+
+    START_TEST("Test Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x4, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is Enabled but rs is zero");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != 0));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x6, 4);
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_mdcfg_n(2, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt != 1)); 
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+
+    START_TEST("Stall MD Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST(); 
+
+    START_TEST("Test Cascading IOPMP Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 3, 0xC0000000, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(31, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+#if (MSI_EN)
+    START_TEST("Test MSI");
+    uint32_t read_data;
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    read_memory(0x8000, 4, (char *)&read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+    free(memory);
+
+    return 0;
+}

--- a/iopmp_ref_model/verif/tests/unnamed_model_2.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_2.c
@@ -17,32 +17,29 @@
 #include "test_utils.h"
 
 // Declarations
-// Register offset to size mapping
-uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
-int test_num;
 iopmp_trans_req_t iopmp_trans_req;
 iopmp_trans_rsp_t iopmp_trans_rsp;
-err_reqinfo_t err_req_info_temp;
-int8_t *memory;
-uint64_t bus_error;
+err_info_t err_info_temp;
 
 int main () {
     uint8_t intrpt;
 
     FAIL_IF(create_memory(1) < 0)
-    
+
+#if (SRC_ENFORCEMENT_EN == 0)
     START_TEST("Test OFF - Read Access permissions");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 3, 0x30, 4);
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Write Access permissions");
@@ -51,12 +48,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Instruction Fetch permissions");
@@ -65,12 +63,13 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - UNKNOWN RRID ERROR");
@@ -79,70 +78,77 @@ int main () {
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
+#if (IOPMP_TOR_EN)
     START_TEST("Test TOR - Partial hit on a priority rule error");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
-    configure_mdcfg_n(2, 2, 4);           // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_mdcfg_n(2, 2, 4);                      // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Read Access");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);                                          // SRCMD_PERM[2] is associated with MD[3]
     write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
-    configure_mdcfg_n(2, 2, 4);           // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_mdcfg_n(2, 2, 4);                                                         // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0xB, 4);        // SRCMD_PERM[2] is associated with MD[3]
-    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0xB, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    configure_mdcfg_n(2, 2, 4);                      // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0xB, 4);         // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0xA, 4);        // SRCMD_PERM[2] is associated with MD[3]
-    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0xA, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    configure_mdcfg_n(2, 2, 4);                      // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0xA, 4);         // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test NA4 - 4Byte Read Access");
     reset_iopmp();
@@ -150,12 +156,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Read Access error");
@@ -164,12 +171,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x10, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Write Access");
@@ -178,12 +186,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Write Access error");
@@ -192,12 +201,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Execute Access");
@@ -206,12 +216,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x17, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Execute Access");
@@ -220,12 +231,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 8Byte Access error");
@@ -234,12 +246,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - For exact 4 Byte error");
@@ -248,12 +261,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access");
@@ -262,12 +276,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x19, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access error");
@@ -276,12 +291,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access error");
@@ -290,12 +306,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access");
@@ -304,12 +321,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access error");
@@ -318,12 +336,13 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access");
@@ -332,34 +351,38 @@ int main () {
     configure_mdcfg_n(30, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERMH, 29, 0x1C, 4);
     configure_mdcfg_n(29, 17, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 74, 4);    // (300 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 74, 4);     // (300 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
-    
+    set_hwcfg0_enable();
+
     configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
     configure_mdcfg_n(30, 25, 4);
     configure_entry_n(ENTRY_ADDR, 18, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 18, 0x18, 4);
+    set_hwcfg0_enable();
 
     configure_entry_n(ENTRY_ADDR, 20, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 20, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDCFG_LCK, updating locked MDCFG field");
@@ -367,14 +390,15 @@ int main () {
     write_register(MDCFGLCK_OFFSET,   0x8, 4);   // MD[0]-MD[3] are locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDCFG_LCK, updating unlocked MDCFG field");
@@ -382,14 +406,15 @@ int main () {
     write_register(MDCFGLCK_OFFSET,   0x4, 4);   // MD[0]-MD[1] are locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating locked ENTRY field");
@@ -397,14 +422,15 @@ int main () {
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
@@ -412,14 +438,15 @@ int main () {
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
     configure_mdcfg_n(2, 5, 4);
-    configure_entry_n(ENTRY_ADDR, 4, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 4, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 4, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test MDLCK register lock bit");
@@ -429,14 +456,15 @@ int main () {
     write_register(MDLCK_OFFSET,   0x10, 4);         // Trying to lock MD[3] but it shouldn't be locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);         // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
 
@@ -447,14 +475,15 @@ int main () {
     write_register(MDCFGLCK_OFFSET,   0x4, 4);   // Updating locked MD's MD[0]-MD[1] are locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK register lock bit");
@@ -464,12 +493,13 @@ int main () {
     write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
@@ -480,8 +510,9 @@ int main () {
     write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
@@ -489,29 +520,30 @@ int main () {
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
     FAIL_IF((err_mfr_temp.svw != 0));
     FAIL_IF((err_mfr_temp.svs != 0));
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
-    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svi != 0));
     FAIL_IF((err_mfr_temp.svs != 1));
-    FAIL_IF((err_mfr_temp.svw != 1));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();    
+    FAIL_IF((err_mfr_temp.svw != 4));
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
     START_TEST("Test Interrupt Suppression is Enabled");
     reset_iopmp();
     write_register(ERR_OFFSET,   0x2, 4);
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1)); // Interrupt is suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt Suppression is disabled");
@@ -521,14 +553,15 @@ int main () {
     configure_mdcfg_n(31, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
     START_TEST("Test Error Suppression is Enabled");
     // Receiver Port Signals
@@ -536,17 +569,18 @@ int main () {
     write_register(ERR_OFFSET,   0x4, 4);
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);               // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is Enabled but rs is zero");
@@ -554,17 +588,18 @@ int main () {
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);               // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is disabled");
@@ -572,17 +607,18 @@ int main () {
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != 0));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is Enabled");
@@ -591,18 +627,19 @@ int main () {
     write_register(ERR_OFFSET,   0x6, 4);
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);                          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is disabled");
@@ -611,76 +648,154 @@ int main () {
     write_register(ERR_OFFSET,   0x2, 4);
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
     configure_mdcfg_n(2, 2, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);            // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    FAIL_IF((intrpt != 1)); 
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((intrpt != 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
+#if ((STALL_BUF_DEPTH != 0) & (IMP_RRIDSCP))
     START_TEST("Stall MD Feature");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     write_register(MDSTALL_OFFSET, 0x10, 4);
     write_register(RRISCP_OFFSET,5,4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-    
+
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
     rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST(); 
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#elif (IMP_RRIDSCP)
+    // Set STALL_BUF_DEPTH zero to test this feature
+    START_TEST("Faulting Stalled Transactions Feature");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x10, 4);
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_mdcfg_n(3, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, STALLED_TRANSACTION);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+#if (IOPMP_RRID_TRANSL_EN)
     START_TEST("Test Cascading IOPMP Feature");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERMH, 3, 0xC0000000, 4);
     configure_mdcfg_n(3, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(31, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
 #if (MSI_EN)
+    START_TEST("Test MSI Write error");
+    uint64_t read_data;
+    reset_iopmp();
+    bus_error = 0x8000;
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_mdcfg_n(31, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    set_hwcfg0_enable();
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    bus_error = 0;
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data == 0x8F); // Interrupt is not suppressed
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+
     START_TEST("Test MSI");
-    uint32_t read_data;
     reset_iopmp();
     write_register(ERR_OFFSET, 0x8F0A, 4);
-    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    read_memory(0x8000, 4, (char *)&read_data);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    read_memory(0x8000, 4, &read_data);
     FAIL_IF(intrpt == 1);
     FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 #endif
+#endif
     free(memory);
+
+#if (SRC_ENFORCEMENT_EN)
+    START_TEST("Test SourceEnforcement Enable Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 0, 0x03, 4);
+    configure_mdcfg_n(0, 2, 4);
+    configure_entry_n(ENTRY_ADDR, 0, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 0, (NAPOT | W | R), 4);
+    set_hwcfg0_enable();
+    receiver_port(31, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+
+    receiver_port(12, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
 
     return 0;
 }

--- a/iopmp_ref_model/verif/tests/unnamed_model_3.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_3.c
@@ -7,7 +7,7 @@
 // Max Supported MDs: 63
 // SRCMD_EN(H) and SPS extension registers are replaced with SRCMD_PERM(H).
 // There is no physical MDCFG table. Each MD has k associated IOPMP entries.
-// SRCMD_PERM(H) only defines permissions, not associated MDs. All IOPMP 
+// SRCMD_PERM(H) only defines permissions, not associated MDs. All IOPMP
 // entries are traversed for address matching and permission checks.
 ***************************************************************************/
 
@@ -16,14 +16,9 @@
 #include "test_utils.h"
 
 // Declarations
-// Register offset to size mapping
-uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
-int test_num;
 iopmp_trans_req_t iopmp_trans_req;
 iopmp_trans_rsp_t iopmp_trans_rsp;
-err_reqinfo_t err_req_info_temp;
-int8_t *memory;
-uint64_t bus_error;
+err_info_t err_info_temp;
 
 
 int main () {
@@ -31,18 +26,20 @@ int main () {
     uint8_t intrpt;
 
     FAIL_IF(create_memory(1) < 0)
-    
+
+#if (SRC_ENFORCEMENT_EN == 0)
     START_TEST("Test OFF - Read Access permissions");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 3, 0x30, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Write Access permissions");
@@ -50,12 +47,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Instruction Fetch permissions");
@@ -63,12 +61,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - UNKNOWN RRID ERROR");
@@ -76,79 +75,85 @@ int main () {
     configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
+#if (IOPMP_TOR_EN)
     START_TEST("Test TOR - Partial hit on a priority rule error");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Read Access");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);                                          // SRCMD_PERM[2] is associated with MD[3]
     write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0xB, 4);        // SRCMD_PERM[2] is associated with MD[3]
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0xB, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0xB, 4);         // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0xA, 4);        // SRCMD_PERM[2] is associated with MD[3]
-    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0xA, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0xA, 4);         // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
-
+#endif
     START_TEST("Test NA4 - 4Byte Read Access");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Read Access error");
@@ -156,12 +161,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x10, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x10, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Write Access");
@@ -169,12 +175,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x13, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Write Access error");
@@ -182,12 +189,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Execute Access");
@@ -195,12 +203,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x17, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x17, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Execute Access");
@@ -208,12 +217,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x13, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 8Byte Access error");
@@ -221,12 +231,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - For exact 4 Byte error");
@@ -234,12 +245,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access");
@@ -247,12 +259,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x19, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x19, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access error");
@@ -260,12 +273,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access error");
@@ -273,12 +287,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access");
@@ -286,12 +301,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x1B, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access error");
@@ -299,12 +315,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access");
@@ -312,60 +329,66 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x1C, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERMH, 29, 0x1C, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 74, 4);    // (300 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 74, 4);     // (300 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
-    
+    set_hwcfg0_enable();
+
     configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
     configure_entry_n(ENTRY_ADDR, 18, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 18, 0x18, 4);
+    set_hwcfg0_enable();
 
     configure_entry_n(ENTRY_ADDR, 20, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 20, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating locked ENTRY field");
     reset_iopmp();
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
     reset_iopmp();
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
-    configure_entry_n(ENTRY_ADDR, 4, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 4, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 4, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK register lock bit");
@@ -374,12 +397,13 @@ int main () {
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
     write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
@@ -388,8 +412,9 @@ int main () {
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
     write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
@@ -397,28 +422,29 @@ int main () {
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
     FAIL_IF((err_mfr_temp.svw != 0));
     FAIL_IF((err_mfr_temp.svs != 0));
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
-    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svi != 0));
     FAIL_IF((err_mfr_temp.svs != 1));
-    FAIL_IF((err_mfr_temp.svw != 1));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();    
+    FAIL_IF((err_mfr_temp.svw != 4));
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
     START_TEST("Test Interrupt Suppression is Enabled");
     reset_iopmp();
     write_register(ERR_OFFSET,   0x2, 4);
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1)); // Interrupt is suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt Suppression is disabled");
@@ -427,65 +453,69 @@ int main () {
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
     START_TEST("Test Error Suppression is Enabled");
     // Receiver Port Signals
     reset_iopmp();
     write_register(ERR_OFFSET,   0x4, 4);
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);               // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is Enabled but rs is zero");
     // Receiver Port Signals
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);               // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is disabled");
     // Receiver Port Signals
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != 0));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is Enabled");
@@ -493,18 +523,19 @@ int main () {
     reset_iopmp();
     write_register(ERR_OFFSET,   0x6, 4);
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);                          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is disabled");
@@ -512,73 +543,148 @@ int main () {
     reset_iopmp();
     write_register(ERR_OFFSET,   0x2, 4);
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);            // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt != 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
+#if ((STALL_BUF_DEPTH != 0) & (IMP_RRIDSCP))
     START_TEST("Stall MD Feature");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);        // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     write_register(MDSTALL_OFFSET, 0x10, 4);
     write_register(RRISCP_OFFSET,5,4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-    
+
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
     rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST(); 
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#elif (IMP_RRIDSCP)
+    // Set STALL_BUF_DEPTH zero to test this feature
+    START_TEST("Faulting Stalled Transactions Feature");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x10, 4);
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);         // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, STALLED_TRANSACTION);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+#if (IOPMP_RRID_TRANSL_EN)
     START_TEST("Test Cascading IOPMP Feature");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERMH, 3, 0xC0000000, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);        // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    set_hwcfg0_enable();
     receiver_port(31, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
+#endif
 
 #if (MSI_EN)
-    START_TEST("Test MSI");
-    uint32_t read_data;
+    START_TEST("Test MSI Write error");
+    uint64_t read_data;
     reset_iopmp();
+    bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
-    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
-    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    read_memory(0x8000, 4, (char *)&read_data);
-    FAIL_IF(intrpt == 1);
-    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    bus_error = 0;
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data == 0x8F);         // Interrupt is not suppressed
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MSI");
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    set_hwcfg0_enable();
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F);         // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 #endif
     free(memory);
+
+#if (SRC_ENFORCEMENT_EN)
+    START_TEST("Test SourceEnforcement Enable Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 0, 0x03, 4);
+    configure_entry_n(ENTRY_ADDR, 0, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 0, (NAPOT | W | R), 4);
+    set_hwcfg0_enable();
+    receiver_port(31, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+
+    receiver_port(12, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
 
     return 0;
 }

--- a/iopmp_ref_model/verif/tests/unnamed_model_3.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_3.c
@@ -1,0 +1,584 @@
+/***************************************************************************
+// Author:  Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the tests that are used to test
+// unamed3 model.
+// Max Supported RRIDs: 32
+// Max Supported MDs: 63
+// SRCMD_EN(H) and SPS extension registers are replaced with SRCMD_PERM(H).
+// There is no physical MDCFG table. Each MD has k associated IOPMP entries.
+// SRCMD_PERM(H) only defines permissions, not associated MDs. All IOPMP 
+// entries are traversed for address matching and permission checks.
+***************************************************************************/
+
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+// Declarations
+// Register offset to size mapping
+uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
+int test_num;
+iopmp_trans_req_t iopmp_trans_req;
+iopmp_trans_rsp_t iopmp_trans_rsp;
+err_reqinfo_t err_req_info_temp;
+int8_t *memory;
+uint64_t bus_error;
+
+
+int main () {
+
+    uint8_t intrpt;
+
+    FAIL_IF(create_memory(1) < 0)
+    
+    START_TEST("Test OFF - Read Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x30, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Write Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Instruction Fetch permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - UNKNOWN RRID ERROR");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - Partial hit on a priority rule error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
+    write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0xB, 4);        // SRCMD_PERM[2] is associated with MD[3]
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0xB, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0xA, 4);        // SRCMD_PERM[2] is associated with MD[3]
+    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0xA, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Read Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x10, 4);
+    receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x13, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Write Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x17, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x17, 4);
+    receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x13, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 8Byte Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - For exact 4 Byte error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x19, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x19, 4);
+    receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x1B, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 29, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 74, 4);    // (300 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_entry_n(ENTRY_ADDR, 18, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 18, 0x18, 4);
+
+    configure_entry_n(ENTRY_ADDR, 20, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 20, 0x1C, 4);
+    receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating locked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 4, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 4, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK register lock bit");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    END_TEST();
+
+    START_TEST("Test MFR Extension");
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    err_mfr_t err_mfr_temp;
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svw != 0));
+    FAIL_IF((err_mfr_temp.svs != 0));
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svs != 1));
+    FAIL_IF((err_mfr_temp.svw != 1));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();    
+
+    START_TEST("Test Interrupt Suppression is Enabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt Suppression is disabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+
+    START_TEST("Test Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x4, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is Enabled but rs is zero");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != 0));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x6, 4);
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt != 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+
+    START_TEST("Stall MD Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST(); 
+
+    START_TEST("Test Cascading IOPMP Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 3, 0xC0000000, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    receiver_port(31, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+#if (MSI_EN)
+    START_TEST("Test MSI");
+    uint32_t read_data;
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    read_memory(0x8000, 4, (char *)&read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+    free(memory);
+
+    return 0;
+}

--- a/iopmp_ref_model/verif/tests/unnamed_model_4.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_4.c
@@ -1,0 +1,579 @@
+/***************************************************************************
+// Author:  Gull Ahmed (gull.ahmed@10xengineers.ai)
+// Date: October 21, 2024
+// Description: This file contains all the tests that are used to test
+// unamed4 model. It is Same as Unnamed Model 3, but the value of k is 
+// programmable.
+***************************************************************************/
+
+#include "iopmp.h"
+#include "config.h"
+#include "test_utils.h"
+
+// Declarations
+// Register offset to size mapping
+uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
+int test_num;
+iopmp_trans_req_t iopmp_trans_req;
+iopmp_trans_rsp_t iopmp_trans_rsp;
+err_reqinfo_t err_req_info_temp;
+int8_t *memory;
+uint64_t bus_error;
+
+int main () {
+
+    uint8_t intrpt;
+
+    FAIL_IF(create_memory(1) < 0)
+    
+    START_TEST("Test OFF - Read Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x30, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Write Access permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - Instruction Fetch permissions");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test OFF - UNKNOWN RRID ERROR");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - Partial hit on a priority rule error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
+    write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0xB, 4);        // SRCMD_PERM[2] is associated with MD[3]
+    write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
+    configure_entry_n(ENTRY_ADDR, 1,  (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0xB, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test TOR - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0xA, 4);        // SRCMD_PERM[2] is associated with MD[3]
+    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
+    configure_entry_n(ENTRY_CFG, 1, 0xA, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Read Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Read Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x10, 4);
+    receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Write Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x13, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Write Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x17, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x17, 4);
+    receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 4Byte No Execute Access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x13, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - 8Byte Access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NA4 - For exact 4 Byte error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
+    configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    receiver_port(30, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x19, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x19, 4);
+    receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte read access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte write access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x1B, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access error");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 29, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 74, 4);    // (300 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    
+    configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
+    configure_entry_n(ENTRY_ADDR, 18, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 18, 0x18, 4);
+
+    configure_entry_n(ENTRY_ADDR, 20, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 20, 0x1C, 4);
+    receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating locked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 4, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 4, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Entry_LCK register lock bit");
+    reset_iopmp();
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    END_TEST();
+
+    START_TEST("Test MFR Extension");
+    write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
+    write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
+    write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // requestor Port Signals
+    err_mfr_t err_mfr_temp;
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svw != 0));
+    FAIL_IF((err_mfr_temp.svs != 0));
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
+    err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
+    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svs != 1));
+    FAIL_IF((err_mfr_temp.svw != 1));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();    
+
+    START_TEST("Test Interrupt Suppression is Enabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1)); // Interrupt is suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt Suppression is disabled");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+
+    START_TEST("Test Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x4, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is Enabled but rs is zero");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != 0));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is Enabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x6, 4);
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt == 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    FAIL_IF((iopmp_trans_rsp.user != USER));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test Interrupt and Error Suppression is disabled");
+    // Receiver Port Signals
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x2, 4);
+    configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((intrpt != 1));
+    FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
+    FAIL_IF((iopmp_trans_rsp.rrid != 2));
+    error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();   
+
+    START_TEST("Stall MD Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+    
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST(); 
+
+    START_TEST("Test Cascading IOPMP Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERMH, 3, 0xC0000000, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    receiver_port(31, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+
+#if (MSI_EN)
+    START_TEST("Test MSI");
+    uint32_t read_data;
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    read_memory(0x8000, 4, (char *)&read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+    free(memory);
+
+    return 0;
+}

--- a/iopmp_ref_model/verif/tests/unnamed_model_4.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_4.c
@@ -2,7 +2,7 @@
 // Author:  Gull Ahmed (gull.ahmed@10xengineers.ai)
 // Date: October 21, 2024
 // Description: This file contains all the tests that are used to test
-// unamed4 model. It is Same as Unnamed Model 3, but the value of k is 
+// unamed4 model. It is Same as Unnamed Model 3, but the value of k is
 // programmable.
 ***************************************************************************/
 
@@ -11,32 +11,29 @@
 #include "test_utils.h"
 
 // Declarations
-// Register offset to size mapping
-uint8_t g_offset_to_size[4096]; // Consider initializing this array if needed
-int test_num;
 iopmp_trans_req_t iopmp_trans_req;
 iopmp_trans_rsp_t iopmp_trans_rsp;
-err_reqinfo_t err_req_info_temp;
-int8_t *memory;
-uint64_t bus_error;
+err_info_t err_info_temp;
 
 int main () {
 
     uint8_t intrpt;
 
     FAIL_IF(create_memory(1) < 0)
-    
+
+#if (SRC_ENFORCEMENT_EN == 0)
     START_TEST("Test OFF - Read Access permissions");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 3, 0x30, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Write Access permissions");
@@ -44,12 +41,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - Instruction Fetch permissions");
@@ -57,12 +55,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 0, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test OFF - UNKNOWN RRID ERROR");
@@ -70,80 +69,86 @@ int main () {
     configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x01, 4);
+    set_hwcfg0_enable();
     receiver_port(70, 364, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, UNKNOWN_RRID);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
+#if (IOPMP_TOR_EN)
     START_TEST("Test TOR - Partial hit on a priority rule error");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Read Access");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);       // SRCMD_PERM[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_PERM, 2, 0x10, 4);                                          // SRCMD_PERM[2] is associated with MD[3]
     write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4); // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);  // IOPMP_ENTRY[1] contains ENTRY_CFG - 9 (TOR with read permissions)
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0x9, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
-    configure_srcmd_n(SRCMD_PERM, 2, 0xB, 4);        // SRCMD_PERM[2] is associated with MD[3]
+    configure_srcmd_n(SRCMD_PERM, 2, 0xB, 4);                                           // SRCMD_PERM[2] is associated with MD[3]
     write_register(HWCFG0_OFFSET, read_register(HWCFG0_OFFSET,   4) & 0xFF04FFFF, 4);   // md_entry_num set to 2
-    configure_entry_n(ENTRY_ADDR, 1,  (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0xB, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    configure_entry_n(ENTRY_ADDR, 1,  (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0xB, 4);                                            // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with read and write permissions)
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS,ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test TOR - 4Byte Write Access");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0xA, 4);        // SRCMD_PERM[2] is associated with MD[3]
-    configure_mdcfg_n(2, 2, 4);            // MDCFG[3].t contains 2
-    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);  // IOPMP_ENTRY[1] contains top range 92
-    configure_entry_n(ENTRY_CFG, 1, 0xA, 4);   // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    configure_entry_n(ENTRY_ADDR, 1, (368 >> 2), 4);
+    configure_entry_n(ENTRY_CFG, 1, 0xA, 4);         // IOPMP_ENTRY[1] contains ENTRY_CFG - (TOR with write permissions)
+    set_hwcfg0_enable();
     receiver_port(2, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR,ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
-
+#endif
     START_TEST("Test NA4 - 4Byte Read Access");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Read Access error");
@@ -151,12 +156,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x10, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x10, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Write Access");
@@ -164,12 +170,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x13, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Write Access error");
@@ -177,12 +184,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte Execute Access");
@@ -190,12 +198,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x17, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x17, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 4Byte No Execute Access");
@@ -203,12 +212,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x13, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x13, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 2, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - 8Byte Access error");
@@ -216,12 +226,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 364, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, PARTIAL_HIT_ON_PRIORITY);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NA4 - For exact 4 Byte error");
@@ -229,12 +240,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x11, 4);
     configure_entry_n(ENTRY_ADDR, 1, (364 >> 2), 4);
     configure_entry_n(ENTRY_CFG, 1, 0x11, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 368, 0, 0, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access");
@@ -242,12 +254,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x19, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x19, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte read access error");
@@ -255,12 +268,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, READ_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_READ_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access error");
@@ -268,12 +282,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_WRITE_ACCESS);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte write access");
@@ -281,12 +296,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x1B, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access error");
@@ -294,12 +310,13 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x18, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access");
@@ -307,60 +324,66 @@ int main () {
     configure_srcmd_n(SRCMD_PERMH, 30, 0x1C, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test NAPOT - 8 Byte Instruction access for non-priority Entry");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERMH, 29, 0x1C, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 74, 4);    // (300 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 74, 4);     // (300 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
-    
+    set_hwcfg0_enable();
+
     configure_srcmd_n(SRCMD_PERMH, 30, 0x18, 4);
     configure_entry_n(ENTRY_ADDR, 18, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 18, 0x18, 4);
+    set_hwcfg0_enable();
 
     configure_entry_n(ENTRY_ADDR, 20, 90, 4);    // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 20, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(30, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating locked ENTRY field");
     reset_iopmp();
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK, updating unlocked ENTRY field");
     reset_iopmp();
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
-    configure_entry_n(ENTRY_ADDR, 4, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 4, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 4, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Entry_LCK register lock bit");
@@ -369,12 +392,13 @@ int main () {
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
     write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
@@ -383,8 +407,9 @@ int main () {
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
     write_register(ENTRYLCK_OFFSET,   0x2, 4);   // ENTRY[0] is locked
     configure_srcmd_n(SRCMD_PERM, 2, 0x1C, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);    // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // requestor Port Signals
@@ -392,28 +417,29 @@ int main () {
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
     FAIL_IF((err_mfr_temp.svw != 0));
     FAIL_IF((err_mfr_temp.svs != 0));
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     err_mfr_temp.raw = read_register(ERR_MFR_OFFSET, 4);
-    FAIL_IF((err_mfr_temp.svi != iopmp_trans_req.rrid));
+    FAIL_IF((err_mfr_temp.svi != 0));
     FAIL_IF((err_mfr_temp.svs != 1));
-    FAIL_IF((err_mfr_temp.svw != 1));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();    
+    FAIL_IF((err_mfr_temp.svw != 4));
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
     START_TEST("Test Interrupt Suppression is Enabled");
     reset_iopmp();
     write_register(ERR_OFFSET,   0x2, 4);
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);     // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x99, 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1)); // Interrupt is suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt Suppression is disabled");
@@ -422,65 +448,69 @@ int main () {
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    FAIL_IF((intrpt == 0)); // Interrupt is not suppressed
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((intrpt == 0));          // Interrupt is not suppressed
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
     START_TEST("Test Error Suppression is Enabled");
     // Receiver Port Signals
     reset_iopmp();
     write_register(ERR_OFFSET,   0x4, 4);
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);               // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is Enabled but rs is zero");
     // Receiver Port Signals
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);               // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE|NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Error Suppression is disabled");
     // Receiver Port Signals
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != 0));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is Enabled");
@@ -488,18 +518,19 @@ int main () {
     reset_iopmp();
     write_register(ERR_OFFSET,   0x6, 4);
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);                          // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (SEXE | SIXE | NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt == 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_SUCCESS));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     FAIL_IF((iopmp_trans_rsp.user != USER));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,0);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 
     START_TEST("Test Interrupt and Error Suppression is disabled");
@@ -507,73 +538,148 @@ int main () {
     reset_iopmp();
     write_register(ERR_OFFSET,   0x2, 4);
     configure_srcmd_n(SRCMD_PERM, 2, 0x1, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);            // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);    // Address Mode is NAPOT, with read permission and exe suppression
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((intrpt != 1));
     FAIL_IF((iopmp_trans_rsp.status != IOPMP_ERROR));
     FAIL_IF((iopmp_trans_rsp.rrid != 2));
     error_record_chk(ILLEGAL_INSTR_FETCH, INSTR_FETCH, 360,1);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST();   
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
 
+#if ((STALL_BUF_DEPTH != 0) & (IMP_RRIDSCP))
     START_TEST("Stall MD Feature");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);        // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
     write_register(MDSTALL_OFFSET, 0x10, 4);
     write_register(RRISCP_OFFSET,5,4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
-    
+
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
     rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
-    END_TEST(); 
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#elif (IMP_RRIDSCP)
+    // Set STALL_BUF_DEPTH zero to test this feature
+    START_TEST("Faulting Stalled Transactions Feature");
+    reset_iopmp();
+    write_register(ERR_OFFSET,   0x10, 4);
+    configure_srcmd_n(SRCMD_PERM, 3, 0x10, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);        // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 1, 0x1C, 4);
+    set_hwcfg0_enable();
+    write_register(MDSTALL_OFFSET, 0x10, 4);
+    write_register(RRISCP_OFFSET,5,4);
+    receiver_port(5, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
+    rridscp_t rridscp_temp;
+    rridscp_temp.raw = read_register(RRISCP_OFFSET,4);
+    FAIL_IF((rridscp_temp.stat != 1));
+    FAIL_IF((iopmp_trans_rsp.rrid != 5));
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, STALLED_TRANSACTION);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
+
+#if (IOPMP_RRID_TRANSL_EN)
     START_TEST("Test Cascading IOPMP Feature");
     reset_iopmp();
     configure_srcmd_n(SRCMD_PERMH, 3, 0xC0000000, 4);
-    configure_entry_n(ENTRY_ADDR, 1, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);        // (364 >> 2) and keeping lsb 0
     configure_entry_n(ENTRY_CFG, 1, 0x1B, 4);
+    set_hwcfg0_enable();
     receiver_port(31, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
 
     // requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_transl != IOPMP_RRID_TRANSL));
     CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
 #if (MSI_EN)
-    START_TEST("Test MSI");
-    uint32_t read_data;
+    START_TEST("Test MSI Write error");
+    uint64_t read_data;
     reset_iopmp();
+    bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
-    write_register(ERR_MSIADDR_OFFSET, 0x2000, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
-    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
+    set_hwcfg0_enable();
     receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
 
     // Requestor Port Signals
-    iopmp_trans_rsp = iopmp_validate_access(iopmp_trans_req, &intrpt);
-    read_memory(0x8000, 4, (char *)&read_data);
-    FAIL_IF(intrpt == 1);
-    FAIL_IF(read_data != 0x8F); // Interrupt is not suppressed
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
-    write_register(ERR_REQINFO_OFFSET,   0, 4);
+    bus_error = 0;
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data == 0x8F);                 // Interrupt is not suppressed
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+
+    START_TEST("Test MSI");
+    reset_iopmp();
+    write_register(ERR_OFFSET, 0x8F0A, 4);
+    write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+    configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
+    configure_entry_n(ENTRY_ADDR, 1, 90, 4);
+    configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);
+    set_hwcfg0_enable();
+    receiver_port(2, 360, 0, 3, INSTR_FETCH, &iopmp_trans_req);
+
+    // Requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    read_memory(0x8000, 4, &read_data);
+    FAIL_IF(intrpt == 1);
+    FAIL_IF(read_data != 0x8F);             // Interrupt is not suppressed
+    CHECK_IOPMP_TRANS(IOPMP_ERROR, ILLEGAL_INSTR_FETCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
 #endif
+#endif
     free(memory);
+
+#if (SRC_ENFORCEMENT_EN)
+    START_TEST("Test SourceEnforcement Enable Feature");
+    reset_iopmp();
+    configure_srcmd_n(SRCMD_PERM, 0, 0x03, 4);
+    configure_entry_n(ENTRY_ADDR, 0, 90, 4);   // (364 >> 2) and keeping lsb 0
+    configure_entry_n(ENTRY_CFG, 0, (NAPOT | W | R), 4);
+    set_hwcfg0_enable();
+    receiver_port(31, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+
+    receiver_port(12, 360, 0, 3, WRITE_ACCESS, &iopmp_trans_req);
+    // requestor Port Signals
+    iopmp_validate_access(&iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
+    CHECK_IOPMP_TRANS(IOPMP_SUCCESS, ENTRY_MATCH);
+    write_register(ERR_INFO_OFFSET,   0, 4);
+    END_TEST();
+#endif
 
     return 0;
 }


### PR DESCRIPTION
This Pull Request introduces the **IOPMP Reference Model**, developed in compliance with the **RISC-V IOPMP Specification Version 0.8, 2025**. This model serves as a reference implementation, ensuring alignment with the latest specification and will be updated as future revisions are released. Just as the **RISC-V IOMMU Specification** repository contains its own reference model, it is imperative that the IOPMP Specification repository includes a corresponding reference model to maintain consistency and support the community's development efforts.
## Supported Features
The **IOPMP Reference Model** incorporates all IOPMP Models and each model can be configured based upon SRCMD_FMT and MDCFG_FMT flags at compilation time. All features outlined in the **RISC-V IOPMP Specification Version 0.8, 2025**. Key feature configuration parameters include:
| **Feature**  | **Possible Values** | **Description**                                                                                                                                                                                                                    |
| ------------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| TOR_EN             | 0/1                       | Indicates if Top-Of-Range (TOR) addressing mode is supported.<br />**0**: TOR not supported. <br />**1**: TOR supported                                                                                                      |
| SPS_EN             | 0/1                       | Indicates if Secondary Permission Settings (SPS) are supported.<br />**0**: SPS not supported. <br />**1**: SPS is supported                                                                                                    |
| PRIENT_PROG        | 0/1                       | Indicates if the `prio_entry` field in HWCFG2 is programmable.<br /> **0**: Field is fixed. <br />**1**: Field is programmable                                                                                             |
| RRID_TRANSL_EN     | 0/1                       | Indicates if tagging a new Requestor ID (RRID) on the initiator port is supported.<br />**0**: Tagging not supported. <br />**1**: New RRID tagging is supported.                                                            |
| RRID_TRANSL_PROG   | 0/1                       | Indicates if the `rrid_transl` field is programmable. <br />**0**: Field is fixed. <br />**1**: Field is programmable                                                                                                      |
| CHK_X              | 0/1                       | Indicates if the IOPMP implements check of an instruction fetches based on the instruction fetches fields<br />**0**: Fields of instruction fetches are ignored<br />**1**: Fields of instruction fetches are not ignored |
| NO_X               | 0/1                       | Valid only if `CHK_X` = 1. <br />**0**: Instruction fetch checks are permissive. <br />**1**: Instruction fetches are always denied.                                                                                       |
| NO_W               | 0/1                       | Indicates if write accesses are always denied.<br />**0**: Write accesses are allowed based on permissions. <br />**1**: Write accesses are always denied.                                                                   |
| STALL_EN           | 0/1                       | Indicates if stalling is supported.<br />**0**: No stalling supported. <br />**1**: Stalling features are implemented.                                                                                                       |
| PEIS               | 0/1                       | Indicates if Per-Entry Interrupt Suppression is supported.<br />**0**: Feature not supported. <br />**1**: Interrupts can be suppressed per entry.                                                                           |
| PEES               | 0/1                       | Indicates if Per-Entry Error Suppression is supported.<br />**0**: Feature not supported. <br />**1**: Errors can be suppressed per entry.                                                                                   |
| MFR_EN             | 0/1                       | Indicates if Multi Fault Record Extension is supported.<br />**0**: Feature not supported. <br />**1**: Subsequent violations will be recorded.                                                                              |
| MD_ENTRY_NUM       | 0 - IMP                   | Indicates the number of entries associated with each Memory Domain (MD) when `MDCFG_FMT` is not 0.<br />Implementation defined value                                                                                                   |
| MD_NUM             | 0 - 63                    | Indicates the maximum number of supported Memory Domain (MD).                                                                                                                                                                            |
| ADDRH_EN           | 0/1                       | Indicates if higher-address fields are available.<br />**0**: Higher-address fields not available. <br />**1**: Higher-address fields are implemented.                                                                       |
| RRID_NUM           | 0 - 65535                 | Indicates the maximum number of Requestor IDs (RRIDs) supported.                                                                                                                                                                         |
| ENTRY_NUM          | 0 - IMP                   | Indicates the total number of entries supported.                                                                                                                                                                                         |
| PRIO_ENTRY         | 1 - ENTRY_NUM             | Indicates the number of entries matched based on priority.                                                                                                                                                                               |
| ERROR_CAPTURE_EN   | 0/1                       | Indicates if the Error Capture Record feature is implemented.<br />**0**: Feature not supported. <br />**1**: Error details can be captured and logged.                                                                      |
| IMP_ERROR_REQID    | 0/1                       | Indicates if `ERR_REQID` is implemented. <br />**0**: Feature not supported. <br />**1**: Errored RRID and Entry num is recorded.                                                                                          |
| IMP_MDLCK          | 0/1                       | Indicates if the Memory Domain Lock (MDLCK) feature is implemented.<br />**0**: Feature is not implemented<br />**1**: Memory domains can be locked.                                                                         |
| REG_INTF_BUS_WIDTH | 4/8                       | Specifies the width (in bytes) of the register interface bus.<br />**4**: 4-byte width. <br />**8**: 8-byte width.                                                                                                           |
| MSI_EN             | 0/1                       | Indicates if Messaged-Signal-Interrupts are supported.<br />**0:** MSI is not supported.<br />**1:** MSI can be generated.                                                                                                |

All IOPMP Models and Mentioned features are tested using C, test files are included in the verif/tests directory.