### PR TITLE
Add new register HWCFG_USER and update version number

### DIFF
--- a/chapter5.adoc
+++ b/chapter5.adoc
@@ -7,11 +7,12 @@ If an optional register is not implemented, the behavior is implementation-depen
 |===
 |OFFSET |Register |Description
 
-.20+|0x0000  2+|{set:cellbgcolor:#D3D3D3} INFO
+.21+|0x0000  2+|{set:cellbgcolor:#D3D3D3} INFO
 |{set:cellbgcolor:#FFFFFF} VERSION |Indicates the specification and the IP vendor.
 |{set:cellbgcolor:#FFFFFF} IMPLEMENTATION | Indicates the implementation version.
 |{set:cellbgcolor:#FFFFFF} HWCFG0~2 |Indicate the configurations of current IOPMP instance.
 |{set:cellbgcolor:#FFFFFF} ENTRYOFFSET |Indicates the internal address offsets of each table.
+|{set:cellbgcolor:#FFFFFF} HWCFG_USER | (Optional) User-defined configurations of current IOPMP instance.
 
 2+|{set:cellbgcolor:#D3D3D3} Programming Protection
 |{set:cellbgcolor:#FFFFFF} MDSTALL/MDSTALLH .2+.^| (Optional) Stall and resume the transaction checks when programming the IOPMP.
@@ -151,6 +152,17 @@ h|Field                         |Bits   |R/W    |Default    |Description
 h|Field                         |Bits   |R/W    |Default    |Description
 |{set:cellbgcolor:#FFFFFF}offset|31:0   |R      |IMP        |Indicate the offset address of the IOPMP array from the base of an IOPMP instance, a.k.a. the address of *VERSION*. Note: the offset is a signed number. That is, the IOPMP array can be placed in front of *VERSION*.  
 |===
+
+*HWCFG_USER* is an optional register to provide users to define their own configurations.
+
+[cols="<2,<1,<1,<1,<6"]
+|===
+5+h|HWCFG_USER{set:cellbgcolor:#D3D3D3}
+5+h|0x002C
+h|Field                         |Bits   |R/W    |Default    |Description
+|{set:cellbgcolor:#FFFFFF}user  |31:0   |IMP    |IMP        | (Optional) user-defined registers
+|===
+
 
 === *Programming Protection Registers*
 

--- a/iopmp.adoc
+++ b/iopmp.adoc
@@ -1,8 +1,8 @@
 [[header]]
 :description: RISC-V IOPMP Architecture Specification
 :company: RISC-V.org
-:revdate: Jan, 2025
-:revnumber: 0.9.2-RC3
+:revdate: Feb, 2025
+:revnumber: 0.7
 :revremark: This document is in development. Assume everything can change. See http://riscv.org/spec-state for details.
 :url-riscv: http://riscv.org
 :doctype: book


### PR DESCRIPTION
To allow users to control user-defined configurations, a register HWCFG_USER (at offset 0x002C) should be added.
The PR also update the version number for the next version.

Summary:
* Update Table 3 for HWCFG_USER in chapter5.adoc.
* Update Section 5.1 for HWCFG_USER in chapter5.adoc.
* Update version number and date in iopmp.adoc.

