### PR TITLE
Fix inconsistency in chapter4.adoc/chapter5.adoc

### DIFF
--- a/chapter4.adoc
+++ b/chapter4.adoc
@@ -17,7 +17,7 @@ The general approach for a security software to the atomicity requirement has th
 ** Step 2: Update IOPMP's settings.
 ** Step 3: Resume the transactions stalled in Step 1.
 
-Stalling a transaction means the IOPMP stops checking its permission until it is resumed. In the meantime, the transaction should wait. For step 1, it might be necessary to verify if the stalling has occurred since some implementations could not immediately stall the desired transactions from receiver ports. Following this, execute the IOPMP updates as step 2, and finally, resume all stalled transactions in step 3.
+Stalling a transaction means the IOPMP stops checking its permission until it is resumed. In the meantime, the transaction should wait. For Step 1, it might be necessary to verify if the stalling has occurred since some implementations could not immediately stall the desired transactions from receiver ports. Following this, execute the IOPMP updates as Step 2, and finally, resume all stalled transactions in Step 3.
 
 [NOTE]
 ====
@@ -32,7 +32,7 @@ For Step 1, it's possible to postpone all transactions until all updates are fin
 
 In Step 2, the decision of whether a transaction should be stalled cannot reference the current settings because these settings are under updating. Therefore, the only reliable information for this decision is the RRID carried by the transaction. To simplify the following descriptions, we use _rrid_stall_ to represent an abstract bit array, where _rrid_stall_[_s_] = 1 indicates that transactions with RRID _s_ must be stalled. The IOPMP stalls a transaction based on its corresponding _rrid_stall_. Please note that it may not be an actual bit array in practice just for easier expression and is not directly accessible by software.
 
-Register *MDSTALL* and *MDSTALLH* control _rrid_stall_. *MDSTALL.md* and *MDSTALLH.mdh* are used to select MDs. Denote _stall_by_md_ to represent the concatenation of *MDSTALL.mdh* and *MDSTALL.md*. That is, _stall_by_md_[30:0] is *MDSTALL.md[30:0]*, and _stall_by_md_[62:31] is *MDSTALLH.mdh[31:0]* if any. An MD _m_ is selected when _stall_by_md_[_m_] = 1. *MDSTALL.exempt* controls the polarity of the selection. An IOPMP updates _rrid_stall_ only when *MDSTALL.exempt* is written. When *MDSTALL.exempt* is written to 0, _rrid_stall_[_s_] is set if RRID _s_ is associated with a selected MD _m_ (_stall_by_md_[_m_] = 1). The SRCMD table defines the association of RRID _s_ and MD _m_. Conversely, when *MDSTALL.exempt* is written to 1, _rrid_stall_[_s_] must be clear if RRID _s_ is associated with a selected MD. This relation can be formulated as follows:
+Register *MDSTALL* and *MDSTALLH* control _rrid_stall_. *MDSTALL.md* and *MDSTALLH.mdh* are used to select MDs. Denote _stall_by_md_ to represent the concatenation of *MDSTALL.mdh* and *MDSTALL.md*. That is, _stall_by_md_[30:0] is *MDSTALL.md[30:0]*, and _stall_by_md_[62:31] is *MDSTALLH.mdh[31:0]* if any. An MD _m_ is selected when _stall_by_md_[_m_] = 1. *MDSTALL.exempt* controls the polarity of the selection. An IOPMP updates _rrid_stall_ only when *MDSTALL.exempt* is written. When *MDSTALL.exempt* is written to 0, _rrid_stall_[_s_] is set if RRID _s_ is associated with a selected MD _m_ (_stall_by_md_[_m_] = 1). The SRCMD table defines the association of RRID _s_ and MD _m_. Conversely, when *MDSTALL.exempt* is written to 1, _rrid_stall_[_s_] must be set if RRID _s_ is not associated with any selected MD. This relation can be formulated as follows:
 
 [.text-center]
 `_rrid_stall_[_s_] <= MDSTALL.exempt ^ ( Reduction_OR (SRCMD(_s_).md & _stall_by_md_));`
@@ -73,7 +73,7 @@ Faulting stalled transactions can be allowed. To allow faulting over stalling wh
 ====
 In certain implementations, rather than stalling the related transactions, the system may opt to fault the checking transactions during an IOPMP atomic update. Faulting transactions can be advantageous if the system lacks sufficient buffer capacity to record and store all transactions during the IOPMP programming process.
 
-This function also can prevent the risk of deadlock in some systems. If an implementation or a system doesn't have sufficient buffer capacity for handling all stalled transactions during programming, the stalled transactions may backpressure from receiver port of the IOPMP and then occur hang on the port due to its implementation limitation. Therefore, the hang on the port potentially causes a deadlock in the system since transactions for programming IOPMP during Step 2 and Step 3 have the possibility to hang indirectly in the circumstance. 
+This function also can prevent the risk of deadlock in some systems. If an implementation or a system doesn't have sufficient buffer capacity for handling all stalled transactions during programming, the stalled transactions may backpressure from receiver port of the IOPMP and then occur hang on the port due to its implementation limitation. Therefore, the hang on the port potentially causes a deadlock in the system since transactions for programming IOPMP during Step 2 and Step 3 of <<#SECTION_4_2, Programming Steps>> have the possibility to hang indirectly in the circumstance. 
 ====
 
 [#SECTION_4_6]
@@ -85,13 +85,8 @@ In order to resume all stalled transactions, the IOPMP can be prompted by writin
 === The Order to Stall
 In Step 1 of <<#SECTION_4_2, Programming Steps>>, *MDSTALL* can be written at most once and before a resume. Writing a non-zero value to *MDSTALL* multiple times after a resume leads to RRIDs' stall states being undefined.
 
-After *MDSTALL* and all *RRIDSCP* are written, the action to stall desired transactions may not take effect immediately in some implementations in which the subsequent setting updates (Step 2) could affect the transactions still under checking. To determine whether the action takes effect, one can read back and check the bit *MDSTALL.is_busy*, which is in the same location as *MDSTALL.exempt* on a write. *is_busy* = 0 indicates it has taken effect; otherwise, it has not. A new writing *RRIDSCP* may temporarily switch *is_busy* to 1 and then switch to 0 at some time.
+After *MDSTALL* and all *RRIDSCP* are written, the action to stall desired transactions may not take effect immediately in some implementations in which the subsequent setting updates (Step 2) could affect the transactions still under checking. To determine whether the action takes effect, one can read back and check the bit *MDSTALL.is_busy*, which is in the same location as *MDSTALL.exempt* on a write. *is_busy* = 0 indicates it has taken effect or no previous write; otherwise, it has not. A new writing *RRIDSCP* may temporarily switch *is_busy* to 1 and then switch to 0 at some time.
 *is_busy* can be wired to 0 if any *MDSTALL* and *RRIDSCP* writing won't cause a race condition of the transactions still under checking and the subsequent setting updates.
-
-[NOTE]
-====
-After writing any value to *MDSTALL*, *MDSTALL.is_busy* must be clear at some time, regardless of whether any RRID is stalled. The software polling the status bit doesn't need to consider whether any RRID will be stalled.
-====
 
 Based on <<#SECTION_4_2, Programming Steps>>, complete steps to program an IOPMP should be followed.
 
@@ -106,11 +101,15 @@ Some steps may be skipped according to the actual implementation.
 
 [#SECTION_4_8]
 === Implementation Options
-All registers described in this chapter are optional. Moreover, these features could be partially implemented. In *MDSTALL.md* and *MDSTALLH.mdh*, not every bit should be implemented even though the corresponding MD is implemented. An unimplemented bit means unselectable and should be wired to zero. To test which bits are implemented, one can write all 1's to *MDSTALL.md* and *MDSTALLH.mdh* and then read them back. An implemented bit returns 1.
+All registers described in this chapter are optional. Moreover, these features could be partially implemented.
+
+In *MDSTALL.md* and *MDSTALLH.mdh*, not every bit should be implemented even though the corresponding MD is implemented. An unimplemented bit means unselectable and should be wired to zero. To test which bits are implemented, one can write all 1's to *MDSTALL.md* and *MDSTALLH.mdh* and then read them back. An implemented bit returns 1.
 
 If an IOPMP implementation has fewer than 32 memory domains, *MDSTALLH* should be wired to zero.
 
 NOTE: An example of partial implementation of *MDSTALL.md*/*MDSTALLH.mdh* is a system with a display controller, which is a latency-sensitive device. On updating the IOPMP, the transactions initiated from the display controller should not be stalled. Thus, one can always use *MDSTALL.exempt*=1 and *MDSTALL.md[_j_]*=1, where MD _j_ is the memory domain for the frame buffer that the display controller keeps accessing. Thus, the system only needs to implement *MDSTALL.md[_j_]*.
+
+*MDSTALL.is_busy* can be wired to 0 if any *MDSTALL* and *RRIDSCP* writing won't cause a race condition of the transactions still under checking and the subsequent setting updates.
 
 If whole *MDSTALL* is not implemented, *MDSTALL*, *MDSTALLH* and *ERR_CFG.stall_violation_en* should always return zero.
 

--- a/chapter5.adoc
+++ b/chapter5.adoc
@@ -38,8 +38,8 @@ If an optional register is not implemented, the behavior is implementation-depen
 .6+|0x1000    2+|{set:cellbgcolor:#D3D3D3} SRCMD Table, _s_ = 0...*HWCFG1.rrid_num*-1, only available when *HWCFG0.srcmd_fmt* = 0.
 |{set:cellbgcolor:#FFFFFF}SRCMD_EN(_s_)/SRCMD_ENH(_s_)    |The bitmapped MD enabling register of the requestor _s_ that *SRCMD_EN(_s_)[_m_]* indicates if the requestor is associated with MD _m_ and *SRCMD_ENH(_s_)[_m_]* indicates if the requestor is associated with MD (_m_+31).
 
-|SRCMD_R(_s_)/SRCMD_RH(_s_)|(Optional) bitmapped MD read eanble register, _s_ corresponding to number of requestors, it indicates requestor _s_  read permission on MDs.
-|SRCMD_W(_s_)/SRCMD_WH(_s_)|(Optional) bitmapped MD write eanble register, _s_ corresponding to number of requestors, it indicates requestor _s_  write permission on MDs.
+|SRCMD_R(_s_)/SRCMD_RH(_s_)|(Optional) bitmapped MD read enable register, _s_ corresponding to number of requestors, it indicates requestor _s_  read permission on MDs.
+|SRCMD_W(_s_)/SRCMD_WH(_s_)|(Optional) bitmapped MD write enable register, _s_ corresponding to number of requestors, it indicates requestor _s_  write permission on MDs.
 2+|{set:cellbgcolor:#D3D3D3} SRCMD Table, _m_ =0...*HWCFG0.md_num*-1, only available when *HWCFG0.srcmd_fmt* = 2. 
 |{set:cellbgcolor:#FFFFFF}SRCMD_PERM(_m_)/SRCMD_PERMH(_m_)
 |The bitmapped permission register of the MD _m_. Bit 2*_s_ of *SRCMD_PERM(_m_).perm* holds the read permission for RRID _s_, and bit 2*_s_+1 of *perm* holds the write permission for RRID _s_, where _s_ &#8804;15. Similarly, bit 2*(_s_-16) of *SRCMD_PERMH(_m_).permh* holds the read permission for RRID _s_, and bit 2*(_s_-16)+1 of *permh* holds the write permission for RRID _s_, where _s_&#8805;16. 
@@ -173,8 +173,17 @@ h|Field                         |Bits   |R/W    |Default    |Description
 5+h|MDSTALL{set:cellbgcolor:#D3D3D3}
 5+h|0x0030
 h|Field                         |Bits   |R/W    |Default    |Description
-|{set:cellbgcolor:#FFFFFF}exempt|0:0    |W      |N/A          | Stall transactions with exempt selected MDs, or Stall selected MDs.
-|is_busy                     |0:0    |R      |0          | 0 indicates  the previous writing *MDSTALL* and *RRIDSCP* have taken effect; otherwise, not.
+|{set:cellbgcolor:#FFFFFF}exempt|0:0    |W      |N/A       a| 
+Stall transactions from selected RRIDs
+
+* 0: the RRIDs are associated with a selected MD
+* 1: the RRIDs are not associated with any selected MD
+
+Please refer <<#SECTION_4_3, Stall transactions>> for detailed operations
+|is_busy                     |0:0    |R      |0          a| Indicates the status of previous writing *MDSTALL* and *RRIDSCP*
+
+* 0: the write has taken effect or no previous write
+* 1: the write has not taken effect
 |md                             |31:1   |WARL      |0          |Writing *md[__m__]*=1 selects MD _m_; reading *md[__m__]* = 1 means MD __m__ selected.
 |===
 


### PR DESCRIPTION
* Fix inconsistency of MSTALL.exempt
* Fix inconsistency of MSTALL.is_busy
* Fix inconsistent style about "Step" of programming step
* Add implementation option of MSTALL.is_busy to Chapter 4.8
