### PR TITLE
Refine descriptions from feedback

### DIFF
--- a/appendix_a3.adoc
+++ b/appendix_a3.adoc
@@ -2,11 +2,13 @@
 [Appendix_A3]
 == A3: Secondary Permission Setting
 
-IOPMP/SPS (Secondary Permission Setting) is an extension to support different transaction requestors to share memory domain while allowing each requestor to have different read, write and instruction permission to a single memory domain. IOPMP/SPS is only supported when the SRCMD table is in the format 0, a.k.a. *HWCFG0.srcmd_fmt*=0. *HWCFG0.sps_en*=1 indicates IOPMP/SPS extention is implemented.
+IOPMP/SPS (Secondary Permission Setting) is an extension to support different transaction requestors to share memory domain while allowing each requestor to have different read, write and instruction permission to a single memory domain. IOPMP/SPS is only supported when the SRCMD Table is in the format 0, a.k.a. *HWCFG0.srcmd_fmt*=0. *HWCFG0.sps_en*=1 indicates IOPMP/SPS extention is implemented.
 
-If IOPMP/SPS extension is implemented, each SRCMD table entry shall additionally define read and write permission registers: *SRCMD_R(_s_)* and *SRCMD_W(_s_)*, and *SRCMD_RH(_s_)* and *SRCMD_WH(_s_)* if applicable. Register *SRCMD_R(_s_)* and *SRCMD_W(_s_)* each has a single fields, *SRCMD_R(_s_).md* and *SRCMD_W(_s_).md* respectively representing the read and write permission for each memory domain for reguestor _s_. Setting lock to *SRCMD_EN(_s_).l* also locks *SRCMD_R(_s_)*, *SRCMD_RH(_s_)*, *SRCMD_W(_s_)*, and *SRCMD_WH(_s_)*.
+If IOPMP/SPS extension is implemented, each SRCMD Table entry shall additionally define read and write permission registers: *SRCMD_R(_s_)* and *SRCMD_W(_s_)*, and *SRCMD_RH(_s_)* and *SRCMD_WH(_s_)* if applicable. Register *SRCMD_R(_s_)* and *SRCMD_W(_s_)* each has a single fields, *SRCMD_R(_s_).md* and *SRCMD_W(_s_).md* respectively representing the read and write permission for each memory domain for reguestor _s_.
 
-IOPMP/SPS has two sets of permission settings: one from IOPMP entry and the other from *SRCMD_R*/*SRCMD_W*. IOPMP/SPS shall check read and write permission on both the SRCMD table and entries, a transaction fail the IOPMP/SPS check if it violates either of the permission settings. That is, it can shrink the permissions defined on an entry according to requestors.
+IOPMP/SPS shares same locks of *SRCMD_EN(_s_)* and *SRCMD_ENH(_s_)*. Setting lock to *SRCMD_EN(_s_).l* locks *SRCMD_R(_s_)*, *SRCMD_RH(_s_)*, *SRCMD_W(_s_)*, and *SRCMD_WH(_s_)*. *MDLCK.md[_m_]* locks *SRCMD_R(_s_).md[_m_]* and *SRCMD_W(_s_).md[_m_]* for all existing RRID _s_. *MDLCKH.mdh[_m_]* also locks *SRCMD_RH(_s_).mdh[_m_]* and *SRCMD_WH(_s_).mdh[_m_]* for all existing RRID _s_. *SRCMD_R*, *SRCMD_RH*, *SRCMD_W*, and *SRCMD_WH* can have prelocked bits fully or partially based on presets of *MDLCK.md*, *MDLCK.mdh* and *SRCMD_EN.l*.
+
+IOPMP/SPS has two sets of permission settings: one from IOPMP entry and the other from *SRCMD_R*/*SRCMD_W*. IOPMP/SPS shall check read and write permission on both the SRCMD Table and entries, a transaction fail the IOPMP/SPS check if it violates either of the permission settings. That is, it can shrink the permissions defined on an entry according to requestors.
 
 The instruction fetch permission on IOPMP/SPS is considered the same as the read permission.
 

--- a/chapter2.adoc
+++ b/chapter2.adoc
@@ -9,23 +9,28 @@ This document refers to the term “secure monitor” as the software responsibl
 h|Term h|Description
 |{set:cellbgcolor:#FFFFFF}AMO| atomic memory operation
 |DC| don't care
+|ID| identifier
 |IMP|implementation-dependent
+|IMSIC| Incoming Message-Signaled Interrupt Controller, defined in the RISC-V advanced interrupt architecture (AIA) specification
+|IOMMU| Input-Output Memory Management Unit, a RISC-V non-ISA specification
 |MD| memory domain
 |MMIO|memory mapped input/output devices
+|MSI| message-signaled interrupts
 |NA4|naturally aligned four-byte region, one of the address matching mode used in RISC-V PMP and IOPMP
 |NAPOT|naturally aligned power-of-2 region, one of the address matching mode used in RISC-V PMP and IOPMP
 |N/A| not available
 |OTP| one-time programmable
 |ROM| read-only memory
+|RRID| Request Role ID
 |RX|receiver
 |SPS| secondary permission setting, an extension of RISC-V IOPMP
 |TOR|top boundary of an arbitrary range, one of the address matching mode used in RISC-V PMP and IOPMP
 |TX|transmitter
-|WARL|write any read legal
-|W1C|write '1' clear 
-|W1CS|write '1' clear and sticky to 0
-|W1S|write '1' set
-|W1SS|write '1' set and sticky to 1
+|WARL|write any read legal, a behavior of fields
+|W1C|write '1' clear, a behavior of single bit fields
+|W1CS|write '1' clear and sticky to 0, a behavior of single bit fields: writing '1' clears the bit. If the bit is cleared, this state remains fixed until IOPMP registers are reset.
+|W1S|write '1' set, a behavior of single bit fields
+|W1SS|write '1' set and sticky to 1, a behavior of single bit fields: writing '1' sets the bit. If the bit is set, this state remains fixed until IOPMP registers are reset.
 |X( _n_ )|the _n_-th register in the register array X, which starts from 0.
 |X[ _n_ ]|the _n_-th bit of a register X or register field X
 |X( _n_ : _m_ )|the _n_-th to _m_-th registers of a register X.
@@ -42,12 +47,19 @@ If all transactions going through the IOPMP are issued by the same transaction r
 An IOPMP has one or multiple requestor ports, one or multiple receiver ports and one control port. A receiver port is where a transaction goes into the IOPMP, and a requestor port is where a transaction leaves it if the transaction passes all the checks. The control port is used to program the IOPMP.
 
 === Memory Domain
-An RRID is an abstract representation of a transaction requestor. It encompasses one or more transaction requestors that are granted identical permissions. A Memory Domain, MD for short, is an abstract representation of a transaction destination that groups a set of memory regions for a specific purpose. MDs are indexed from zero. For example, a network interface controller, NIC, may have three memory regions: an RX region, a TX region, and a region of control registers. We could group them into one MD. If a processor can fully control the NIC, it can be associated with the MD. An RRID associated with a MD may not have full permissions on all memory regions of the MD. The permission of each region is defined in the corresponding IOPMP entry. Additionally, there is an extension to adhere the permission to the MD that will be introduced in the <<#APPENDIX_A3, Appendix A3>>.
+An RRID is an abstract representation of a transaction requestor. It encompasses one or more transaction requestors that are granted identical permissions. A memory domain, MD for short, is an abstract representation of a transaction destination that groups a set of memory regions for a specific purpose. MDs are indexed from zero. For example, a network interface controller, NIC, may have three memory regions: an RX region, a TX region, and a region of control registers. We could group them into one MD. If a processor can fully control the NIC, the processor can be associated with the MD.
 
-It’s important to note that, generally speaking, a single RRID can be associated with multiple Memory Domains (MDs), and vice versa. However, certain configurations may impose restrictions on this flexibility, which will be discussed in the following chapter.
+It’s important to note that, generally speaking, a single RRID can be associated with multiple memory domains (MDs), and a MD can be associated with multiple RRIDs. SRCMD Table is a one of fundamental structures in IOPMP to indicate associations between RRIDs and MDs, which will be introduced in <<#SECTION_3_2, SRCMD Table Formats>>.
 
+MDCFG Table also is one of fundamental structures in IOPMP to define a set of memory regions in a MD, which will be introduced in <<#SECTION_3_3, MCDFG Table Formats>>. An IOPMP entry defines a single memory region, which will be introduced in <<#SECTION_2_5, IOPMP Entry and IOPMP Entry Array>>. 
+
+An RRID associated with a MD may not have full permissions on all memory regions of the MD, because the permission of each region is defined in the corresponding IOPMP entry. Additionally, some specific configurations of SRCMD Table can define the permission to a whole MD in SRCMD Table that will be introduced in <<#SECTION_3_2_3, SRCMD Table Format 2>> and <<#APPENDIX_A3, Appendix A3. Secondary Permission Setting>>.
+
+Certain configurations of SRCMD Table and MDCFG Table may impose restrictions on this flexibility, which will be discussed in <<#IOPMP_Tables_and_Configuration_Protection, Chapter 3. IOPMP Tables and Configuration Protection>>.
+
+[#SECTION_2_5]
 === IOPMP Entry and IOPMP Entry Array
-The IOPMP entry array, contains IOPMP entries. Each entry, starting from an index of zero, includes a specified memory region, the corresponding permissions, and optional features about error reactions and user customized attributes.
+The IOPMP entry array, contains *HWCFG1.entry_num* IOPMP entries. Each entry, starting from an index of zero, includes a specified memory region, the corresponding permissions, and optional features about error reactions and user customized attributes.
 
 For an entry indexed by _i_, *ENTRY_ADDR(_i_)*, *ENTRY_ADDRH(_i_)* and *ENTRY_CFG(_i_).a* encode the memory region in the same way as the RISC-V PMP. *ENTRY_ADDR(_i_)* and *ENTRY_ADDRH(_i_)* are the encoded address for the IOPMP with addresses greater than 34 bits. For addresses less than and equal to 34 bits, only *ENTRY_ADDR(_i_)* is in use. To determine whether *ENTRY_ADDRH(_i_)* are implemented, one can check *HWCFG0.addrh_en*. Please refer <<#HWCFG0, HWCFG0>> for more details of *HWCFG0.addrh_en*. *ENTRY_CFG(_i_).a* is the address mode, which are OFF, NA4, NAPOT, and TOR. Please refer to the RISC-V privileged spec for the details of the encoding schemes. *HWCFG0.tor_en* = 1 indicates the IOPMP supports TOR address mode.
 
@@ -61,12 +73,23 @@ Since the address encoding scheme of TOR refers to the previous entry's memory r
 
 *ENTRY_CFG(_i_).r/w/x* indicate the read access, write access and instruction fetch permission and they are WARL. That is, an implementation can decide which bits are programmable or hardwired and which bit combinations are unwanted. An IOPMP can differentiate between read and instruction fetch accesses when *HWCFG0.chk_x* is 1.
 
-Every entry has several WARL fields *sire/siwe/sixe/esre/eswe/esxe*, suppressing interrupts and bus error responses for its error reaction, and will be introduced in <<#SECTION_2_7, Error Reactions>>.
-The optional register *ENTRY_USER_CFG* stores customized attributes for an entry. To determine whether the register is implemented, one can check *HWCFG0.user_cfg_en*.
+*ENTRY_CFG(_i_)* also contains optional WARL fields: *sire*, *siwe*, *sixe*, *esre*, *eswe*, and *esxe*. These fields are used to control error reactions per entry, such as interrupt triggering and bus error responses. The detailed usages will be introduced in <<#SECTION_2_7, Error Reactions>>.
 
-Memory domains are a way of dividing the IOPMP entry array into different subarrays. Each subarray is a Memory Domain. Each IOPMP entry can belong to at most one Memory Domain, while a Memory Domain could have multiple IOPMP entries. 
+The optional register *ENTRY_USER_CFG(_i_)* stores customized attributes for an entry. To determine whether the register is implemented, one can check *HWCFG0.user_cfg_en*.
 
-When an RRID is associated with a Memory Domain, it is also inherently associated with all the entries that belong to that Memory Domain. An RRID could be associated with multiple Memory Domains, and one Memory Domain could be associated with multiple RRIDs.
+Any entry with index &#8805; *HWCFG1.entry_num* is not available. That is,
+
+* Registers of the entry are not implemented.
+* Address mode of the entry is treated as OFF when the IOPMP retrieves the entry in permission checks.
+
+Memory domains are a way of dividing the IOPMP entry array into different subarrays. Each subarray is a memory domain. Each IOPMP entry can belong to at most one memory domain, while a memory domain could have multiple IOPMP entries. 
+
+[NOTE]
+====
+A memory domain may have an IOPMP entry with index &#8805; *HWCFG1.entry_num* due to its register encoding or implementation. The entry is not available.
+====
+
+When an RRID is associated with a memory domain, it is also inherently associated with all the entries that belong to that memory domain.
 
 [#SECTION_2_6]
 === Priority and Matching Logic
@@ -82,27 +105,39 @@ IOPMP entries exhibit partial prioritization. Entries with indices smaller than 
 
 NOTE: The specification incorporates both priority and non-priority entries due to considerations of security, latency, and area. Priority entries, which are locked, safeguard the most sensitive data, even in the event of secure software being compromised. However, implementing a large number of these priority entries results in higher latency and increased area usage. On the other hand, non-priority entries are treated equally and can be cached in smaller numbers. This approach reduces the amortized latency, power consumption, and area when the locality is sufficiently high. Thus, the mix of entry types in the specification allows for a balance between security and performance.
 
-The entry with the highest priority that 
+An entry qualifies as a matching entry if:
 
-* matches any byte of the incoming transaction; and
-* is associated with the RRID carried by the transaction.
+* For priority entries, it matches any byte of the incoming transaction;
+* For non-priority entries, it matches all bytes of the incoming transaction;
+* It is associated with the RRID carried by the transaction; and
+* It holds the highest priority among entries that meet the previous criteria.
 
-If the matching entry is priority entry, the matching entry must match all bytes of a transaction, or the transaction is illegal with error type = "partial hit on a priority rule" (0x04), irrespective of its permission. An entry has own permission and permission from Memory Domain to grant a transaction permission. If a priority entry is matched but doesn't grant transaction permission to operate, the transaction is illegal with error type = "illegal read access" (0x01) for read access transaction, "illegal write access/AMO" (0x02) for write access/atomic memory operation (AMO) transaction, or "illegal instruction fetch" (0x03) for instruction fetch transaction.
+[NOTE]
+====
+Multiple matching entries are allowed for non-priority entries because they share the lowest priority.
+====
 
-NOTE: To grant an AMO transaction permission, entries and/or Memory Domains must have read access permission and write access permission.
+An entry has own permission and optional permission from corresponding memory domain to grant a transaction permission. An IOPMP can carry the optional permission from SRCMD Table to IOPMP entry array for the corresponding memory domain if it supports <<#SECTION_3_2_3, SRCMD Table Format 2>> or <<#APPENDIX_A3, SPS extension>>.
+
+If the matching entry is priority entry, the matching entry must match all bytes of a transaction, or the transaction is illegal with error type = "partial hit on a priority rule" (0x04), irrespective of its permission. If a priority entry is matched but doesn't grant transaction permission to operate, the transaction is illegal with error type = "illegal read access" (0x01) for read access transaction, "illegal write access/AMO" (0x02) for write access/atomic memory operation (AMO) transaction, or "illegal instruction fetch" (0x03) for instruction fetch transaction.
+
+[NOTE]
+====
+To grant an AMO transaction permission, entries and/or memory domains must have read access permission and write access permission.
+====
 
 [NOTE]
 ====
 Some AMO implementations of I/O agents are using a non-atomic read-modify-write sequence which could contain a read access transaction and a write access transaction, not single AMO transaction. Therefore, IOPMP possiblly captures error type = "illegal read access" (0x01) when read permission for the read-modify-write sequence from the I/O agents is not granted.
 ====
 
-Let's consider a non-priority entry matching all bytes of a transaction. It is legal if the entry grants the transaction permission to operate. When multiple non-priority entries match all bytes of a transaction and one of them allows the transaction, the transaction is legal. If none of them allows, the transaction is illegal with error type = "illegal read access" (0x01) for read access transaction, "illegal write access/AMO" (0x02) for write access/AMO  transaction, or "illegal instruction fetch" (0x03) for instruction fetch transaction.
+Let's consider the matching entry is non-priority entry. The transaction is legal if the entry grants the transaction permission to operate. When one of multiple non-priority matching entries grants the transaction permission to operate, the transaction is legal. If no matching entry allows, the transaction is illegal with error type = "illegal read access" (0x01) for read access transaction, "illegal write access/AMO" (0x02) for write access/AMO transaction, or "illegal instruction fetch" (0x03) for instruction fetch transaction.
 
-Finally, if no such above entry exists, the transaction is illegal with error type = "not hit any rule" (0x05).
+Finally, if no matching entry exists, the transaction is illegal with error type = "not hit any rule" (0x05).
 
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
-[title="an example block diagram of an IOPMP. It illustrates the checking flow of an IOPMP. This IOPMP takes three inputs: RRID, the transaction type (read/write), and the request range (address/len). It first looks up the SRCMD table according to the RRID carried by the incoming transaction to retrieve associated MD indexes and the corresponding permissions related to these MDs. By the MD indexes, the IOPMP looks up the MDCFG table to get the belonging entry indexes. The final step checks the access right according to the above entry indexes and corresponding permissions. An interrupt, an error response, and/or a record is generated once the transaction fails the permission check in the step.", id=iopmp-block-diagram]
+[title="an example block diagram of an IOPMP. It illustrates the checking flow of an IOPMP. This IOPMP takes three inputs: RRID, the transaction type (read/write), and the request range (address/len). It first looks up the SRCMD Table according to the RRID carried by the incoming transaction to retrieve associated MD indexes and the corresponding permissions related to these MDs. By the MD indexes, the IOPMP looks up the MDCFG Table to get the belonging entry indexes. The final step checks the access right according to the above entry indexes and corresponding permissions. An interrupt, an error response, and/or a record is generated once the transaction fails the permission check in the step.", id=iopmp-block-diagram]
 image::images/iopmp_unit_block_diagram.png[]
 
 [#SECTION_2_7]
@@ -115,7 +150,7 @@ Upon detecting an illegal transaction, the IOPMP could initiate three of the fol
 
 * Log the error details in IOPMP error record registers.
 
-The interrupt enabling on an IOPMP violation can be configured globally via *ERR_CFG* register or optionally locally through the *ENTRY_CFG* register for each entry. The *ERR_CFG.ie* bit serves as the global interrupt enable configuration bit. Every entry _i_ has three optional interrupt suppression bits in register *ENTRY_CFG(_i_)*, *sire*, *siwe*, and *sixe* to suppress interrupt triggering due to illegal reads, illegal writes and illegal instruction fetches on the corresponding entry, respectively. *HWCFG0.peis* is 1 if an implementation supports *sire*, *siwe*, or *sixe*. The interrupt pending indication is equivalent to the error valid indication, both are flagged through the *ERR_INFO.v* bit. An IOPMP interrupt will be triggered when a transaction is illegal and the interrupt is not suppressed. An IOPMP triggers interrupt by global interrupt enable configuration bit *ie* and suppression bits (*sire*, *siwe*, or *sixe*) in entries if a transaction is illegal with error type = "illegal read access" (0x01), "illegal write access/AMO" (0x02), or "illegal instruction fetch" (0x03) and *peis* is 1. On the other hand, if a transaction doesn't only violate permissions on entries, an IOPMP triggers interrupt only by global interrupt enable configuration bit *ie*. The permissions include permission bits in entries (*ENTRY_CFG(_i_).r/w/x*) and permission bits from SRCMD table (please refer <<#SECTION_3_2, SRCMD Table Formats>> for the details) to corresponding entries. The relation of interrupt control with interrupt suppression bits for an illegal transaction can be more precisely described as follows:
+The interrupt enabling on an IOPMP violation can be configured globally via *ERR_CFG* register or optionally locally through the *ENTRY_CFG* register for each entry. The *ERR_CFG.ie* bit serves as the global interrupt enable configuration bit. Every entry _i_ has three optional interrupt suppression bits in register *ENTRY_CFG(_i_)*, *sire*, *siwe*, and *sixe* to suppress interrupt triggering due to illegal reads, illegal writes and illegal instruction fetches on the corresponding entry, respectively. *HWCFG0.peis* is 1 if an implementation supports *sire*, *siwe*, or *sixe*. The interrupt pending indication is equivalent to the error valid indication, both are flagged through the *ERR_INFO.v* bit. An IOPMP interrupt will be triggered when a transaction is illegal and the interrupt is not suppressed. An IOPMP triggers interrupt by global interrupt enable configuration bit *ie* and suppression bits (*sire*, *siwe*, or *sixe*) in entries if a transaction is illegal with error type = "illegal read access" (0x01), "illegal write access/AMO" (0x02), or "illegal instruction fetch" (0x03) and *peis* is 1. On the other hand, if a transaction doesn't only violate permissions on entries, an IOPMP triggers interrupt only by global interrupt enable configuration bit *ie*. The permissions include permission bits in entries (*ENTRY_CFG(_i_).r/w/x*) and permission bits from SRCMD Table (please refer <<#SECTION_3_2, SRCMD Table Formats>> for the details) to corresponding entries. The relation of interrupt control with interrupt suppression bits for an illegal transaction can be more precisely described as follows:
 
 An entry indexed by _i_ has the highest priority and matches all bytes of the illegal transaction, and error type of the illegal transaction is: 
 
@@ -141,7 +176,7 @@ NOTE: Such local interrupt control mechanism can be beneficial in scenarios such
 
 Transactions that violate the IOPMP rule will by default yield a bus error. Additionally, the bus error response behavior on an IOPMP violation can be optionally configured globally via *ERR_CFG* register or locally through each *ENTRY_CFG* register. The IOPMP will signal the bus to the presence of a violation but will suppress the bus error if *ERR_CFG.rs* is implemented and set to 1 on a violation.  User-defined suppression behavior allows, for example, a read response of 0x0.  Likewise, the bus error response on an illegal write or instruction fetch. 
 
-In the same way, the bus error response behavior can be set up globally and individually for each IOPMP entry. *ERR_CFG.rs* globally suppresses returning a bus error on illegal access. When global suppression is disabled, individual per-entry suppression is possible using *sere*, *sewe*, and *sexe* for illegal read, illegal write, and illegal instruction fetch, respectively. *HWCFG0.pees* is 1 if an IOPMP implements *sere*, *sewe*, and *sexe*. An IOPMP will respond with a bus error when a transaction is illegal and the bus error is not suppressed. Bus error response behavior of an IOPMP is controlled by global bus error response suppression configuration bit *rs* and suppression bits (*sere*, *sewe*, or *sexe*) in entries if a transaction only violates permissions on entries and *pees* is 1. On the other hand, if a transaction doesn't only violate permissions on entries, bus error response behavior of an IOPMP is controlled only by bus error response suppression configuration bit *rs*. The permissions include permission bits in entries (*ENTRY_CFG(_i_).r/w/x*) and permission bits from SRCMD table (please refer <<#SECTION_3_2, SRCMD Table Formats>> for the details) to corresponding entries. The relation of bus error response suppression control with suppression bits in entries for an illegal transaction can be more precisely described as follows:
+In the same way, the bus error response behavior can be set up globally and individually for each IOPMP entry. *ERR_CFG.rs* globally suppresses returning a bus error on illegal access. When global suppression is disabled, individual per-entry suppression is possible using *sere*, *sewe*, and *sexe* for illegal read, illegal write, and illegal instruction fetch, respectively. *HWCFG0.pees* is 1 if an IOPMP implements *sere*, *sewe*, and *sexe*. An IOPMP will respond with a bus error when a transaction is illegal and the bus error is not suppressed. Bus error response behavior of an IOPMP is controlled by global bus error response suppression configuration bit *rs* and suppression bits (*sere*, *sewe*, or *sexe*) in entries if a transaction only violates permissions on entries and *pees* is 1. On the other hand, if a transaction doesn't only violate permissions on entries, bus error response behavior of an IOPMP is controlled only by bus error response suppression configuration bit *rs*. The permissions include permission bits in entries (*ENTRY_CFG(_i_).r/w/x*) and permission bits from SRCMD Table (please refer <<#SECTION_3_2, SRCMD Table Formats>> for the details) to corresponding entries. The relation of bus error response suppression control with suppression bits in entries for an illegal transaction can be more precisely described as follows:
 
 An entry indexed by _i_ has the highest priority and matches all bytes of the illegal transaction, and error type of the illegal transaction is: 
 

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -22,7 +22,7 @@ Every *SRCMD_EN(_s_)* has 1-bit field *l* for SRCMD Table protection. The bit is
 
 For a system requiring more memory domains than 63, please refer to <<#APPENDIX_A2, Appendix A2. Run Out Memory Domains>>.
 
-If SPS extension is supported, an entry has addtional registers. These registers are described in <<#APPENDIX_A3, Appendix A3. Secondary Permission Setting>>.
+If SPS extension is supported, an entry has additional registers. These registers are described in <<#APPENDIX_A3, Appendix A3. Secondary Permission Setting>>.
 
 [#SECTION_3_2_2]
 ==== SRCMD Table Format 1

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -115,7 +115,7 @@ Format 1 and 2 do not implement the register *MDCFGLCK*.
 
 [NOTE]
 ====
-If *MDCFG(_m_)* is locked for MD _m_, while *MDCFG(_m_-1)* is not locked, it could lead to the potential addition or removal of unexpected IOPMP entries within the MD _m_. This can occur by manipulating *MDCFG(_m_-1).t*. Thus, the specification requires that *MDCFG(_m_)* is locked for MD _m_, all its preceding MDCFG Table entries should be locked.
+If *MDCFG(_m_)* is locked for MD _m_, while *MDCFG(_m_-1)* is not locked, it could lead to the potential addition or removal of unexpected IOPMP entries within the MD _m_. This can occur by manipulating *MDCFG(_m_-1).t*. Thus, the specification requires that *MDCFG(_m_)* is locked for MD _m_, all its preceding MDCFG Table entries (*MDCFG(0)* to *MDCFG(_m_-1)*) should be locked.
 ====
 
 [#SECTION_3_5_3]

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -4,7 +4,7 @@ The spec offers several IOPMP configurations to accommodate varied platforms. Us
 
 [#SECTION_3_1]
 === SRCMD Table and MDCFG Table
-When a IOPMP receives a transaction with RRID _s_, IOPMP first lookups SRCMD table to find out all the memory domains associated to requestor _s_ and the corresponding permissions. An IOPMP instance can support up to 65,535 requestors, the actual number of requestor can be implementation-defined and is indicated in *HWCFG1* register. The SRCMD table defines the mapping from a transaction requestor to its associated MDs and corresponding permissions if having. The mapping can be in one of three formats specified in a read only field *HWCFG0.srcmd_fmt* and described in <<#SECTION_3_2, SRCMD Table Formats>>. Besides, the SPS extension can limit the permission associated with RRID described in <<#APPENDIX_A3, Appendix 3>>.
+When a IOPMP receives a transaction with RRID _s_, IOPMP first lookups SRCMD Table to find out all the memory domains associated to requestor _s_ and the corresponding permissions. An IOPMP instance can support up to 65,535 requestors, the actual number of requestor can be implementation-defined and is indicated in *HWCFG1* register. The SRCMD Table defines the mapping from a transaction requestor to its associated MDs and corresponding permissions if having. The mapping can be in one of three formats specified in a read only field *HWCFG0.srcmd_fmt* and described in <<#SECTION_3_2, SRCMD Table Formats>>. Besides, the SPS extension can limit the permission associated with RRID described in <<#APPENDIX_A3, Appendix A3>>.
 
 When the associated memory domains are retrieved, an IOPMP finds the entries. The MDCFG defines which memory domain every entry belongs to. An entry can belong to at most one memory domain, but a memory domain can own zero or more entries. MDCFG can be in one of three formats, specified in a read only field *HWCFG0.mdcfg_fmt* and described in <<#SECTION_3_3, MDCFG Table Formats>>.
 
@@ -16,19 +16,21 @@ Format 0 and 2 of the SRCMD Table use a bit map to associate every RRID with mem
 
 [#SECTION_3_2_1]
 ==== SRCMD Table Format 0
-In Format 0, the SRCMD table is an array and indexed by RRID. Every entry in the array is a set of registers. The register *SRCMD_EN(_s_)* must be implemented for the existing RRID _s_. If SPS extension described in <<#APPENDIX_A3, Appendix A3>> is supported, *SRCMD_R(_s_)* and *SRCMD_W(_s_)* are implemented. Every bit in the 31-bit field *SRCMD_EN(_s_).md* indicates a memory domain. If the number of MDs is more than 31, the register *SRCMD_ENH(_s_)* and the field *SRCMD_ENH(_s_).mdh* can be implemented to support up to 63 memory domains. SPS also includes the registers *SRCMD_RH(_s_)* and *SRCMD_WH(_s_)*, and the fields *SRCMD_RH(_s_).mdh* and *SRCMD_WH(_s_).mdh*. The bit *SRCMD_EN(_s_).l* is used to lock the set of registers indexed by RRID _s_.
+In Format 0, the SRCMD Table is an array and indexed by RRID. Every entry in the array is a set of registers. The register *SRCMD_EN(_s_)* must be implemented for the existing RRID _s_. Every bit in the 31-bit field *SRCMD_EN(_s_).md* indicates a memory domain. Bit _j_ in *SRCMD_EN(_s_).md* indicates if MD _j_ is associated with RRID _s_. If the number of MDs is more than 31, the register *SRCMD_ENH(_s_)* and its 32-bit field *SRCMD_ENH(_s_).mdh* can be implemented to support up to 63 memory domains. Bit _j_ in *SRCMD_ENH(_s_).mdh* indicates if MD (_j_ + 31) is associated with RRID _s_. For unimplemented memory domains, the corresponding bits should be hardwired read-only zero.
 
-For easier description, in the following, we denote *SRCMD(_s_)* a 64-bit register representing the concatenation of *SRCMD_ENH(_s_)* for the higher word and *SRCMD_EN(_s_)* for the lower word. Field *SRCMD(_s_).md* is the concatenation of *SRCMD_ENH(_s_).mdh* and *SRCMD_EN(_s_).md*, and bit *SRCMD(_s_).l* is bit *SRCMD_EN(_s_).l*.
+Every *SRCMD_EN(_s_)* has 1-bit field *l* for SRCMD Table protection. The bit is described in <<#SECTION_3_5_1, SRCMD Table Protection>>.
 
-Field *SRCMD(_s_).md* is a bitmapped field with up to 63 bits and is implemented from the lowest bit. Bit *md[_j_]* in *SRCMD(_s_)* indicates if MD _j_ is associated with RRID _s_. For unimplemented memory domains, the corresponding bits should be hardwired read-only zero. An IOPMP supports up to 63 memory domains. For a system requiring more memory domains than 63, please refer to <<#APPENDIX_A2, Appendix A2>>.
+For a system requiring more memory domains than 63, please refer to <<#APPENDIX_A2, Appendix A2. Run Out Memory Domains>>.
+
+If SPS extension is supported, an entry has addtional registers. These registers are described in <<#APPENDIX_A3, Appendix A3. Secondary Permission Setting>>.
 
 [#SECTION_3_2_2]
 ==== SRCMD Table Format 1
-The bitmap implementation of Format 1 facilitates the sharing of regions between RRIDs. It is specifically tailored for scenarios where there are minimal to no shared regions. In this format, each RRID is exactly associated with a single MD, eliminating the necessity for SRCMD table lookups. Each RRID _i_ is directly associated with MD _i_, resulting in advantages in terms of area, latency, and system complexity. However, duplication of entries occurs when shared regions are required, representing a potential drawback. In the format, the SRCMD table and *MDLCK(H)* registers are not implemented, and the SPS extension is not supported.
+The bitmap implementation of Format 1 specifically tailored for scenarios where there are minimal to no shared regions. In this format, each RRID is exactly associated with a single MD, eliminating the necessity for SRCMD Table lookups. Each RRID _i_ is directly associated with MD _i_, resulting in advantages in terms of area, latency, and system complexity. However, duplicated entry settings when a scenario requires shared regions, representing a potential drawback. In the format, the SPS extension is not supported.
 
 [#SECTION_3_2_3]
 ==== SRCMD Table Format 2
-This format also has a physical SRCMD table of an array, like Format 0, but the array is indexed by the memory domain index.  For MD _m_, *SRCMD_PERM(_m_)* and *SRCMD_PERMH(_m_)* are implemented at the same addresses as *SRCMD_EN(_s_)* and *SRCMD_ENH(_s_)*. That is, there is no *SRCMD_EN(H)* in the format and every RRID implicitly associates all implemented memory domains. That is, the format outputs the permission for every MD according to an RRID. Thus, there is no SPS extension, *SRCMD_R(H)* and *SRCMD_W(H)*.
+This format also has a physical SRCMD Table of an array, like Format 0, but the array is indexed by the memory domain index.  For MD _m_, *SRCMD_PERM(_m_)* and *SRCMD_PERMH(_m_)* are implemented at the same addresses as *SRCMD_EN(_s_)* and *SRCMD_ENH(_s_)*. That is, there is no *SRCMD_EN(H)* in the format and every RRID implicitly associates all implemented memory domains. That is, the format outputs the permission for every MD according to an RRID. Thus, this format doesn't support SPS extension.
 
 *SRCMD_PERM(_m_).r[_s_]* indicates the read permission and instruction fetch permission of RRID _s_ belongs to the memory domain _m_. *SRCMD_PERM(_m_).w[_s_]* indicates write permission of RRID _s_ belongs to the memory domain _m_. *SRCMD_PERM(_m_).r* and *SRCMD_PERM(_m_).w* are adjacent. That is, *SRCMD_PERM(_m_).r[_s_]* and *SRCMD_PERM(_m_).w[_s_]* are located at the bits (_s_ * 2) and  (_s_ * 2 + 1), respectively. For RRID indexed higher than 15, *SRCMD_PERMH(_m_)* is used. IOPMP looks at permissions in  *SRCMD_PERM(H)* and *ENTRY_CFG.r/w/x*.  As long as one of them grants the transaction under checking, it is legal. If one wants to use only *SRCMD_PERM(H)*, all *ENTRY_CFG.r/w/x* can be wired to zero.
 
@@ -38,7 +40,13 @@ The MDCFG table is used to map a memory domain to its own entries. It can be vie
 
 [#SECTION_3_3_1]
 ==== MDCFG Table Format 0
-In the format, every memory domain _m_ has a register, *MDCFG(_m_)*. Field *MDCFG(_m_).t* indicates the top index of IOPMP entry belonging to the memory domain _m_. An entry with index _j_ belongs to MD _m_ if *MDCFG(_m_-1).t* &#8804; _j_ < *MDCFG(_m_).t*, where _m_ > 0. MD 0 owns the IOPMP entries with index _j_ < *MDCFG(0).t*. *MDCFG(_m_+1).t* should be programmed greater than or equal to *MDCFG(_m_).t*. The IOPMP behavior of improperly programming them is implementation-dependent as long as 
+In the format, every memory domain _m_ has a register, *MDCFG(_m_)*. Field *MDCFG(_m_).t* encodes the range of IOPMP entry belonging to the memory domain _m_. That is,
+
+* an entry with index _j_ belongs to MD _m_ if *MDCFG(_m_-1).t* &#8804; _j_ < *MDCFG(_m_).t*, where _m_ > 0;
+* an entry with index _j_ belongs to MD 0 if _j_ < *MDCFG(0).t*; and
+* *MDCFG(_m_+1).t* should be programmed greater than or equal to *MDCFG(_m_).t*; otherwise, MDCFG Table is improperly programmed. 
+
+The MDCFG Table behavior of improperly programming them is implementation-dependent as long as 
 
 * an entry must belong to at most one memory domain; and
 * the index of an entry in a lower-indexed memory domain should be lower than that in a higher-indexed memory domain.
@@ -50,7 +58,12 @@ A proper setting of MDCFGs must maintain *MDCFG(_m_).t* &#8804; *MDCFG(_m_+1).t*
 
 [#SECTION_3_3_2]
 ==== MDCFG Table Format 1
-There is no physical MDCFG table in the format. Each memory domain has exactly _k_ entries, where _k_ is implementation-dependent and non-programmable. The value of the read-only field *HWCFG0.md_entry_num* is the _k_ value minus 1. The register *MDCFGLCK* should not be implemented.
+There is no physical MDCFG Table in the format. Each memory domain has exactly _k_ entries, where _k_ is implementation-dependent and non-programmable. The value of the read-only field *HWCFG0.md_entry_num* is the _k_ value minus 1. The register *MDCFGLCK* should not be implemented.
+
+[NOTE]
+====
+( *HWCFG0.md_entry_num* + 1 ) * *HWCFG0.md_num* can be greater than *HWCFG1.num_entry*. Behavior of any entry with index &#8805; *HWCFG1.num_entry* is described on <<#SECTION_2_5, IOPMP Entry and IOPMP Entry Array>>.
+====
 
 For a particular case of _k_=1 (*HWCFG0.md_entry_num*=0), every memory domain has exactly one entry. One can skip the concept of the memory domain when using such an IOPMP.
 
@@ -63,7 +76,7 @@ This format is based on Format 1, except *HWCFG0.md_entry_num* is programmable. 
 For the sake of convenience of discussion, some highly used combinations of *HWCFG0* have an alias name, which are *srcmd_fmt*=0 and *mdcfg_fmt*=0 as the full model, *srcmd_fmt*=0 and *mdcfg_fmt*=1 as the rapid-_k_ model, where _k_ = (*md_entry_num* + 1), *srcmd_fmt*=0 and *mdcfg_fmt*=2 as the dynamic-_k_ model, where _k_ = (*md_entry_num* + 1), *srcmd_fmt*=1 and *mdcfg_fmt*=0 as the isolation model, and *srcmd_fmt*=1 and *mdcfg_fmt*=1 as the compact-_k_ model, where _k_ = (*md_entry_num* + 1).
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
-[title="an example block diagram of the rapid-4 model. The flow is the same as in <<iopmp-block-diagram>>, except the MDCFG table is simplified to a constant mapping illustrated in the dashed box. In this example, every MD has exactly four entries."]
+[title="an example block diagram of the rapid-4 model. The flow is the same as in <<iopmp-block-diagram>>, except the MDCFG Table is simplified to a constant mapping illustrated in the dashed box. In this example, every MD has exactly four entries."]
 image::images/iopmp_unit_block_diagram_rapid_4.png[]
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
@@ -71,47 +84,47 @@ image::images/iopmp_unit_block_diagram_rapid_4.png[]
 image::images/iopmp_unit_block_diagram_compact_4.png[]
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
-[title="an example block diagram of the model implements SRCMD table format 2 and MDCFG table format 1 with HWCFG0.md_entry_num is 0. In this example, every MD has exactly single entry, i.e., the entry index is equal to the MD index."]
+[title="an example block diagram of the model implements SRCMD Table format 2 and MDCFG Table format 1 with HWCFG0.md_entry_num is 0. In this example, every MD has exactly single entry, i.e., the entry index is equal to the MD index."]
 image::images/iopmp_unit_block_diagram_srcmd_fmt2.png[]
 
 [#SECTION_3_5]
 === Configuration Protection
-The term 'lock' refers to a hardware feature that renders one or more fields or registers nonprogrammable until the IOPMP is reset. This feature serves to maintain the integrity of essential configurations in the event of a compromise of secure software. In cases where a lock bit is programmable, it is expected to be reset to '0' and sticky to '1' upon receiving a write of '1'.
+The term 'lock' refers to a hardware feature that renders one or more fields or registers nonprogrammable until the IOPMP is reset. This feature serves to maintain the integrity of essential configurations in the event of a compromise of secure software. In cases where a lock bit is programmable, it is expected to be reset to '0' and is a W1SS field.
 
 [#SECTION_3_5_1]
 ==== SRCMD Table Protection
-The two fields *MDLCK.md* and *MDLCKH.mdh* have 63 bits together. Every bit is used to lock the association bits with a memory domain in the SRCMD table. In Format 0,  for MD 0 &#x2264; _m_ &#x2264; 30, *MDLCK.md[_m_]* locks *SRCMD(_s_).md[_m_]* for all existing RRID _s_. In Format 1, there is no *MDLCK*. In Format 2, *MDLCK.md[_m_]* locks both *SRCMD_PERM(_m_)* and *SRCMD_PERMH(_m_)*. For MD 31 &#x2264; _m_ &#x2264; 62, one should use *MDLCKH.mdh* to lock corresponding bits.
+In Format 0, every *SRCMD_EN(_s_)* register has a bit *l* at bit 0, which is used to lock registers *SRCMD_EN(_s_)*, and *SRCMD_ENH(_s_)* if any.
+
+The two fields *MDLCK.md* and *MDLCKH.mdh* have 63 bits together. Every bit is used to lock the association bits with a memory domain in the SRCMD Table. In Format 0, for MD 0 &#x2264; _m_ &#x2264; 30, *MDLCK.md[_m_]* locks *SRCMD(_s_).md[_m_]* for all existing RRID _s_. In Format 1, there is no *MDLCK*. In Format 2, *MDLCK.md[_m_]* locks both *SRCMD_PERM(_m_)* and *SRCMD_PERMH(_m_)*. For MD 31 &#x2264; _m_ &#x2264; 62, one should use *MDLCKH.mdh* to lock corresponding bits.
 
 Bit *MDLCK.l* is a sticky to 1 and indicates if *MDLCK* and *MDLCKH* are locked.
 
 *MDLCK.md* is optional, if not implemented, *MDLCK.md* should be wired to 0 and *MDLCK.l* should be wired to 1. *MDLCKH* is optional.
 
-Besides, in Format 0, every *SRCMD_EN(_s_)* register has a bit *l*, which is used to lock registers *SRCMD_EN(_s_)*, *SRCMD_ENH(_s_)*, *SRCMD_R(_s_)*, *SRCMD_RH(_s_)*, *SRCMD_W(_s_)*, and *SRCMD_WH(_s_)* if any.
-
 [NOTE]
 ====
-Locking SRCMD table in either way can prevent the table from being altered accidentally or maliciously.
+Locking SRCMD Table in either way can prevent the table from being altered accidentally or maliciously.
 By locking the association of the MD containing the configuration regions of a component, one can prevent the component from being configured by unwanted RRIDs. To make it more secure, one can use another high-priority MD containing the same regions but no permission, let it be associated with all unwanted RRIDs, and then lock the two MDs' associations by *MDLCK*/*MDLCKH*. By adopting this approach, it is possible to safeguard the configuration from direct access by potentially compromised security software.
 ====
 
 [#SECTION_3_5_2]
 ==== MDCFG Table Protection
-Register *MDCFGLCK* is designed to partially or fully lock the MDCFG table for Format 0. *MDCFGLCK* consists of two fields: *MDCFGLCK.l* and *MDCFGLCK.f*. *MDCFG(_m_)* is locked if _m_< *MDCFGLCK.f*. *MDCFGLCK.f* is incremental-only. Any smaller value can not be written into it. The bit *MDCFGLCK.l* is used to lock *MDCFGLCK*.
+Register *MDCFGLCK* is designed to partially or fully lock the MDCFG Table for Format 0. *MDCFGLCK* consists of two fields: *MDCFGLCK.l* and *MDCFGLCK.f*. *MDCFG(_m_)* is locked if _m_< *MDCFGLCK.f*. *MDCFGLCK.f* is incremental-only. Any smaller value can not be written into it. The bit *MDCFGLCK.l* is used to lock *MDCFGLCK*.
 
 Format 1 and 2 do not implement the register *MDCFGLCK*.
 
 [NOTE]
 ====
-If a MD is locked, while its preceding MD is not locked, it could lead to the potential addition or removal of unexpected entries within the locked MD. This can occur by manipulating the top index of the preceding unlocked MD. Thus, the specification requires that one MD is locked, all its preceding MDs should be locked.
+If *MDCFG(_m_)* is locked for MD _m_, while *MDCFG(_m_-1)* is not locked, it could lead to the potential addition or removal of unexpected IOPMP entries within the MD _m_. This can occur by manipulating *MDCFG(_m_-1).t*. Thus, the specification requires that *MDCFG(_m_)* is locked for MD _m_, all its preceding MDCFG Table entries should be locked.
 ====
 
 [#SECTION_3_5_3]
 ==== Entry Protection
-IOPMP entry protection is also related to the other IOPMP entries belonging to the same memory domain. For a MD, locked entries should be placed in the higher priority. Otherwise, when the secure monitor is compromised, one unlocked entry in higher priority can overwrite all the other locked or non-locked entries in lower priority.  A register *ENTRYLCK* is define to indicate the number of nonprogrammable entries. *ENTRYLCK* register has two fields: *ENTRYLCK.l* and *ENTRYLCK.f*. Any IOPMP entry with index _i_ &#8804; *ENTRYLCK.f* is not programmable. If *ENTRYLCK.f* is initialized to 0 and can be increased only when written. Besides, *ENTRYLCK.l* is the lock to *ENTRYLCK.f* and itself. If *ENTRYLCK* is hardwired, *ENTRYLCK.l* should be wired to 1.
+IOPMP entry protection is also related to the other IOPMP entries belonging to the same memory domain. For a MD, locked entries should be placed in the higher priority. Otherwise, when the secure monitor is compromised, one unlocked entry in higher priority can overwrite all the other locked or non-locked entries in lower priority.  A register *ENTRYLCK* is define to indicate the number of nonprogrammable entries. *ENTRYLCK* register has two fields: *ENTRYLCK.l* and *ENTRYLCK.f*. Any IOPMP entry with index _i_ &#8804; *ENTRYLCK.f* is not programmable. *ENTRYLCK.f* is incremental-only. Any smaller value can not be written into it. Besides, *ENTRYLCK.l* is the lock to *ENTRYLCK.f* and itself. If *ENTRYLCK* is hardwired, *ENTRYLCK.l* should be wired to 1.
 
 
 [#SECTION_3_6]
 === Prelocked Configurations
 Prelocked configurations in the specification mean the fields or registers are locked right after reset. In practice, they could be hardwired and/or implemented by read-only memory. Every lock mechanism in this chapter can be optionally pre-locked.
-The non-zero reset value of *MDCFGLCK.f* reflects the pre-locked *MDCFG(_j_)*, where _j_< *MDCFGLCK.f*. The non-zero reset value of *ENTRYLCK.f* reflects the existing pre-locked entries. *SRCMD_EN/R/W(H)* can have prelocked bits fully or partially based on presets of *MDLCK.md* and *SRCMD_EN.l*. Similarly, *SRCMD_PERM(H)* also can have prelocked bits fully or partially based on presets of *MDLCK.md*.
+The non-zero reset value of *MDCFGLCK.f* reflects the pre-locked *MDCFG(_j_)*, where _j_< *MDCFGLCK.f*. The non-zero reset value of *ENTRYLCK.f* reflects the existing pre-locked entries. *SRCMD_EN(H)* can have prelocked bits fully or partially based on presets of *MDLCK.md* and *SRCMD_EN.l*. Similarly, *SRCMD_PERM(H)* also can have prelocked bits fully or partially based on presets of *MDLCK.md*.
 The rest of the lock bits can be preset, too. They are *ERR_CFG.l*, *MDLCK.l*, *MDCFGLCK.l*, and *ENTRYLCK.l*.

--- a/chapter4.adoc
+++ b/chapter4.adoc
@@ -32,7 +32,7 @@ For Step 1, it's possible to postpone all transactions until all updates are fin
 
 In Step 2, the decision of whether a transaction should be stalled cannot reference the current settings because these settings are under updating. Therefore, the only reliable information for this decision is the RRID carried by the transaction. To simplify the following descriptions, we use _rrid_stall_ to represent an abstract bit array, where _rrid_stall_[_s_] = 1 indicates that transactions with RRID _s_ must be stalled. The IOPMP stalls a transaction based on its corresponding _rrid_stall_. Please note that it may not be an actual bit array in practice just for easier expression and is not directly accessible by software.
 
-Register *MDSTALL* and *MDSTALLH* control _rrid_stall_. *MDSTALL.md* and *MDSTALLH.mdh* are used to select MDs. Denote _stall_by_md_ to represent the concatenation of *MDSTALL.mdh* and *MDSTALL.md*. That is, _stall_by_md_[30:0] is *MDSTALL.md[30:0]*, and _stall_by_md_[62:31] is *MDSTALLH.mdh[31:0]* if any. An MD _m_ is selected when _stall_by_md_[_m_] = 1. *MDSTALL.exempt* controls the polarity of the selection. An IOPMP updates _rrid_stall_ only when *MDSTALL.exempt* is written. When *MDSTALL.exempt* is written to 0, _rrid_stall_[_s_] is set if RRID _s_ is associated with a selected MD _m_ (_stall_by_md_[_m_] = 1). The SRCMD table defines the association of RRID _s_ and MD _m_. Conversely, when *MDSTALL.exempt* is written to 1, _rrid_stall_[_s_] must be set if RRID _s_ is not associated with any selected MD. This relation can be formulated as follows:
+Register *MDSTALL* and *MDSTALLH* control _rrid_stall_. *MDSTALL.md* and *MDSTALLH.mdh* are used to select MDs. Denote _stall_by_md_ to represent the concatenation of *MDSTALL.mdh* and *MDSTALL.md*. That is, _stall_by_md_[30:0] is *MDSTALL.md[30:0]*, and _stall_by_md_[62:31] is *MDSTALLH.mdh[31:0]* if any. An MD _m_ is selected when _stall_by_md_[_m_] = 1. *MDSTALL.exempt* controls the polarity of the selection. An IOPMP updates _rrid_stall_ only when *MDSTALL.exempt* is written. When *MDSTALL.exempt* is written to 0, _rrid_stall_[_s_] is set if RRID _s_ is associated with a selected MD _m_ (_stall_by_md_[_m_] = 1). The SRCMD Table defines the association of RRID _s_ and MD _m_. Conversely, when *MDSTALL.exempt* is written to 1, _rrid_stall_[_s_] must be set if RRID _s_ is not associated with any selected MD. This relation can be formulated as follows:
 
 [.text-center]
 `_rrid_stall_[_s_] <= MDSTALL.exempt ^ ( Reduction_OR (SRCMD(_s_).md & _stall_by_md_));`
@@ -43,13 +43,13 @@ Where:
 * & is bitwise logical AND operator, and
 * Reduction_OR() is a function that applies bitwise logical OR across all input values.
 
-As to <<#SECTION_3_2_3, SRCMD table Format 2>>, *SRCMD(_s_).md[_m_]* in the above equation is: ‘0’ for all unimplemented MD _m_ and ‘1’ for an implemented MD _m_ because every RRID associates all implemented MDs.
+As to <<#SECTION_3_2_3, SRCMD Table Format 2>>, *SRCMD(_s_).md[_m_]* in the above equation is: ‘0’ for all unimplemented MD _m_ and ‘1’ for an implemented MD _m_ because every RRID associates all implemented MDs.
 
 For any unimplemented MD, the corresponding bit in *MDSTALL.md* or *MDSTALLH.mdh* should be wired to 0.
 
 _rrid_stall_ should be updated only when *MDSTALL.exempt* is written, that is, when *MDSTALL* is written. When *MDSTALLH* is written, the only action is to hold the value.
 
-NOTE: Although _rrid_stall_ is derived from the SRCMD table, it should be updated only when *MDSTALL.exempt* is written. We cannot use the table when stalling transactions because the table updates may still be in progress when the IOPMP decides if a transaction should be stalled. Writing *MDSTALL* is just like capturing a snapshot of the table at the moment right before updating any settings. The _rrid_stall_ reflects the SRCMD table before any updates. 
+NOTE: Although _rrid_stall_ is derived from the SRCMD Table, it should be updated only when *MDSTALL.exempt* is written. We cannot use the table when stalling transactions because the table updates may still be in progress when the IOPMP decides if a transaction should be stalled. Writing *MDSTALL* is just like capturing a snapshot of the table at the moment right before updating any settings. The _rrid_stall_ reflects the SRCMD Table before any updates. 
 
 NOTE: When writing *MDSTALL*, the specification only defines the transactions with RRID=_s_ must be stalled for all _rrid_stall_[_s_] = 1. It doesn't request the rest of the transactions to stall or not. It only asks that all transactions be resumed when writing *MDSTALL* with a zero.
 
@@ -59,7 +59,7 @@ Writing *RRIDSCP* register is an optional substep after writing *MDSTALL* within
 
 [NOTE]
 ====
-*MDSTALL*/*MDSTALLH* only stall the RRIDs based on the SRCMD table at the moment of writing *MDSTALL*. _rrid_stall_ is not updated when the SRCMD table is updated. Besides, _rrid_stall_ is set or clear only for those RRIDs associated with given MDs. The RRIDSCP is used to fine-tune the _rrid_stall_ if writing *MDSTALL*/*MDSTALLH* doesn't fulfill the desired _rrid_stall_ values.
+*MDSTALL*/*MDSTALLH* only stall the RRIDs based on the SRCMD Table at the moment of writing *MDSTALL*. _rrid_stall_ is not updated when the SRCMD Table is updated. Besides, _rrid_stall_ is set or clear only for those RRIDs associated with given MDs. The RRIDSCP is used to fine-tune the _rrid_stall_ if writing *MDSTALL*/*MDSTALLH* doesn't fulfill the desired _rrid_stall_ values.
 ====
 
 The *RRIDSCP* register comprises two fields: a 2-bit *RRIDSCP.op* and a field for *RRIDSCP.rrid*. By setting *RRIDSCP.op* = 1, the _rrid_stall_[_s_] is set for _s_ = *RRIDSCP.rrid*. Conversely, by setting *RRIDSCP.op* = 2, the _rrid_stall_[_s_] is clear for _s_ = *RRIDSCP.rrid*. This register is used to fine-tune the result of writing *MDSTALL*/*MDSTALLH*. The writing *RRIDSCP.op* = 0 querys the value of _rrid_stall_[_s_] for a valid _s_. The value will be returned in the two most significant bits in the following reading *RRIDSCP*. *RRIDSCP.op*=3 is reserved.

--- a/chapter5.adoc
+++ b/chapter5.adoc
@@ -19,8 +19,8 @@ If an optional register is not implemented, the behavior is implementation-depen
 |RRIDSCP 
 
 2+|{set:cellbgcolor:#D3D3D3} Configuration Protection
-|{set:cellbgcolor:#FFFFFF} MDLCK/MDLCKH | (Optional) lock register for SRCMD table.
-|{set:cellbgcolor:#FFFFFF} MDCFGLCK | (Optional) lock register for MDCFG table.
+|{set:cellbgcolor:#FFFFFF} MDLCK/MDLCKH | (Optional) lock register for SRCMD Table.
+|{set:cellbgcolor:#FFFFFF} MDCFGLCK | (Optional) lock register for MDCFG Table.
 |{set:cellbgcolor:#FFFFFF} ENTRYLCK | Lock register for IOPMP entry array.
 
 2+|{set:cellbgcolor:#D3D3D3} Error Reporting
@@ -80,11 +80,11 @@ h|Field                         |Bits   |R/W    |Default    |Description
 h|Field                         |Bits   |R/W    |Default    |Description
 |{set:cellbgcolor:#FFFFFF}mdcfg_fmt |1:0    |R      |IMP        a|Indicate the MDCFG format
 
-* 0x0: Format 0. MDCFG table is implemented.
+* 0x0: Format 0. MDCFG Table is implemented.
 
-* 0x1: Format 1. No MDCFG table. *HWCFG.md_entry_num* is fixed.
+* 0x1: Format 1. No MDCFG Table. *HWCFG.md_entry_num* is fixed.
 
-* 0x2: Format 2. No MDCFG table. *HWCFG.md_entry_num* is programmable.
+* 0x2: Format 2. No MDCFG Table. *HWCFG.md_entry_num* is programmable.
 
 * 0x3: reserved.
 
@@ -93,7 +93,7 @@ Please refer to <<#SECTION_3_3, MDCFG Table Formats>> for details.
 
 * 0x0: Format 0. *SRCMD_EN(_s_)* and *SRCMD_ENH(_s_)* are available.
 
-* 0x1: Format 1. No SRCMD table.
+* 0x1: Format 1. No SRCMD Table.
 
 * 0x2: Format 2. *SRCMD_PERM(_m_)* and *SRCMD_PERMH(_m_)* are available.
 
@@ -216,7 +216,7 @@ h|Field                         |Bits       |R/W    |Default    |Description
 
 === *Configuration Protection Registers*
 
-*MDLCK* and *MDLCKH* are optional registers with a bitmap field to indicate which MDs are locked in the SRCMD table. 
+*MDLCK* and *MDLCKH* are optional registers with a bitmap field to indicate which MDs are locked in the SRCMD Table. 
 
 [cols="<2,<1,<1,<1,<6"]
 |===
@@ -235,7 +235,7 @@ h|Field                         |Bits       |R/W    |Default    |Description
 |{set:cellbgcolor:#FFFFFF}mdh   |31:0       |WARL   |0          | *mdh[_m_]* is sticky to 1 and indicates if *SRCMD_ENH(_s_).mdh[_m_]*, *SRCMD_RH(_s_).mdh[_m_]* and *SRCMD_WH(_s_).mdh[_m_]* are locked for all RRID _s_.
 |===
 
-*MDCFGLCK* is the lock register to MDCFG table. Available only when MDCFG is in Format 0.
+*MDCFGLCK* is the lock register to MDCFG Table. Available only when MDCFG is in Format 0.
 
 [cols="<2,<1,<1,<1,<6"]
 |===
@@ -396,29 +396,31 @@ h|Field                         |Bits       |R/W    |Default    |Description
 |===
 
 === *MDCFG Table Registers*
-MDCFG table is a lookup to specify the number of IOPMP entries that is associated with each MD. For different formats:
+MDCFG Table is a lookup to specify the number of IOPMP entries that is associated with each MD. For different formats:
 
-. Format 0: MDCFG table is implemented.
+. Format 0: MDCFG Table is implemented.
 
-. Format 1 and format 2: No MDCFG table.
+. Format 1 and format 2: No MDCFG Table.
 
 [cols="<2,<1,<1,<1,<6"]
 |===
 5+h|{set:cellbgcolor:#D3D3D3} MDCFG(_m_), _m_ = 0...HWCFG0.md_num-1, support up to 63 MDs
 5+h|0x0800 + (_m_)*4
 h|Field                         |Bits       |R/W    |Default    |Description
-|{set:cellbgcolor:#FFFFFF}t     |15:0       |WARL   |DC/IMP         a|Indicate the top range of memory domain _m_. An IOPMP entry with index _j_ belongs to MD _m_                 
+|{set:cellbgcolor:#FFFFFF}t     |15:0       |WARL   |DC/IMP         a| Indicate the encoding the range of memory domain _m_. An IOPMP entry with index _j_ belongs to MD _m_                 
       
-                     - If *MDCFG(_m_-1).t* ≤ _j_ < *MDCFG(_m_).t,* where m>0. MD0 owns the IOPMP entries with index _j_ < *MDCFG(0).t*.
-                     - If *MDCFG(_m_-1).t* >= *MDCFG(_m_).t*, then MD _m_  is empty.
+- If *MDCFG(_m_-1).t* ≤ _j_ < *MDCFG(_m_).t,* where m > 0.
+- If _j_ < *MDCFG(0).t* where m = 0.
+- If *MDCFG(_m_-1).t* > *MDCFG(_m_).t*, then MDCFG Table is improperly programmed. Please refer <<#SECTION_3_3_1, MDCFG Table Format 0>> for IOPMP behavior of improperly programming.
+
 |{set:cellbgcolor:#FFFFFF}rsv    |31:16       |ZERO   |0 |Must be zero on write, reserved for future 
 |===
 
 
 === *SRCMD Table Registers*
-Format 1 does not implement the SRCMD table registers.
+Format 1 does not implement the SRCMD Table registers.
 
-*SRCMD_EN(_s_)* and *SRCMD_ENH(_s_)* are available when the SRCMD table format (*HWCFG0.srcmd_fmt*) is 0.
+*SRCMD_EN(_s_)* and *SRCMD_ENH(_s_)* are available when the SRCMD Table format (*HWCFG0.srcmd_fmt*) is 0.
 
 [cols="<2,<1,<1,<1,<6"]
 |===
@@ -456,7 +458,7 @@ h|Field                         |Bits             |R/W  |Default |Description
 |{set:cellbgcolor:#FFFFFF}permh     | 31:0 | WARL | DC | Holds two bits per RRID that give the RRID’s read and write permissions for the entry. Bit 2*(_s_-16) holds the read permission for RRID _s_, and bit 2*(_s_-16)+1 holds the write permission for RRID _s_, where _s_ &#8805;16. The register is implemented when *HWCFG0.rrid_num* > 16.
 |===
 
-*SRCMD_R*, *SRCMD_RH*, *SRCMD_W* and *SRCMD_WH* are optional registers for the SRCMD table in Format 0; When SPS extension is enabled, the IOPMP checks both the R/W/X and the *ENTRY_CFG.r/w/x* permission and follows a fail-first rule.
+*SRCMD_R*, *SRCMD_RH*, *SRCMD_W* and *SRCMD_WH* are optional registers for the SRCMD Table in Format 0; When SPS extension is enabled, the IOPMP checks both the R/W/X and the *ENTRY_CFG.r/w/x* permission and follows a fail-first rule.
 
 [cols="<2,<1,<1,<1,<6"]
 |===


### PR DESCRIPTION
Refine descriptions for some feedback from Qualcomm (https://lists.riscv.org/g/tech-iopmp/message/363) and issue #49, #50.

Summary of the PR:
* Refine concepts about memory domains in Section 2.4.
* Clarify issue #50 in Section 2.5.
* Refine matching rules in Section 2.6.
* Remove redundant descriptions about lock bit in Section 3.2.
* Clarify issue #49 in Section 3.3.1.
* Add a note for clarifying issue #50 in Section 3.3.2.
* Refine the note of MDCFGLCK in Section 3.5.2.
* Fix inconsistency in Section 3.5.3.
* Move descriptions about SPS extension from Section 3.5 to Appendix A3.
* Fix missing acronyms.
* Fix inconsistent terms.