### PR TITLE
Several changes for reference model

### DIFF
--- a/iopmp_ref_model/Makefile
+++ b/iopmp_ref_model/Makefile
@@ -9,11 +9,18 @@ COVFLAGS =
 ifeq ($(cov), 1)
 COVFLAGS += -fprofile-arcs -ftest-coverage -lgcov --coverage
 endif
+asan =
+ASAN_CFLAGS =
+ASAN_LDFLAGS =
+ifeq ($(asan), 1)
+ASAN_CFLAGS += -fsanitize=address -fno-omit-frame-pointer -O1 -g3
+ASAN_LDFLAGS += -lasan
+endif
 
 # Compiler and flags
 CC := gcc
-CFLAGS := -Wall -Werror $(COVFLAGS) -I./include -Iverif/ -fPIC
-LDFLAGS := -lm
+CFLAGS := -Wall -Werror $(COVFLAGS) $(ASAN_CFLAGS) -I./include -Iverif/ -fPIC
+LDFLAGS := -lm $(ASAN_LDFLAGS)
 
 # Common source files
 COMMON_SOURCES := $(SRC_DIR)/iopmp_reg.c \
@@ -138,6 +145,7 @@ help:
 	@echo "                        Example: make build model=full_model"
 	@echo "  sharedLib=1           Build shared libraries instead of static ones"
 	@echo "  cov=1                 Enable code coverage during compilation"
+	@echo "  asan=1                Enable AddressSanitizer"
 	@echo ""
 	@echo "Available Models:"
 	@echo "  full_model            SRCMD_FMT = 0, MDCFG_FMT = 0"

--- a/iopmp_ref_model/include/iopmp_registers.h
+++ b/iopmp_ref_model/include/iopmp_registers.h
@@ -667,7 +667,11 @@ typedef union {
         err_reqaddr_t    err_reqaddr;
         err_reqaddrh_t   err_reqaddrh;
         err_reqid_t      err_reqid;
+        #if (IOPMP_MFR_EN)
         err_mfr_t        err_mfr;
+        #else
+        uint32_t         reserved11;
+        #endif
         #if (MSI_EN)
         err_msiaddr_t    err_msiaddr;
         err_msiaddrh_t   err_msiaddrh;

--- a/iopmp_ref_model/src/iopmp_error_capture.c
+++ b/iopmp_ref_model/src/iopmp_error_capture.c
@@ -43,7 +43,9 @@ void errorCapture(perm_type_e trans_type, uint8_t error_type, uint16_t rrid, uin
         g_reg_file.err_reqid.eid  = entry_id;
 
     // If an error was previously logged, handle a subsequent violation
-    } else if (!checkRridSv(rrid) && g_reg_file.hwcfg0.mfr_en && (!error_suppress | !intrpt_suppress)) {
+    }
+#if (IOPMP_MFR_EN)
+    else if (!checkRridSv(rrid) && g_reg_file.hwcfg0.mfr_en && (!error_suppress | !intrpt_suppress)) {
         // Update violation window
         setRridSv(rrid);
     }
@@ -55,12 +57,14 @@ void errorCapture(perm_type_e trans_type, uint8_t error_type, uint16_t rrid, uin
             break;
         }
     }
+#endif
 
     // Generate Interrupt
     if (!err_reqinfo_v)
         generate_interrupt(intrpt);
 }
 
+#if (IOPMP_MFR_EN)
 /**
   * @brief Sets the corresponding bit in the error subsequent violations (SV) structure for a given RRID.
   *
@@ -79,3 +83,4 @@ void setRridSv(uint16_t rrid) {
 int checkRridSv(uint16_t rrid) {
     return (err_svs.sv[rrid/16].svw >> (rrid % 16)) & 0x1;
 }
+#endif

--- a/iopmp_ref_model/src/iopmp_reg.c
+++ b/iopmp_ref_model/src/iopmp_reg.c
@@ -660,16 +660,20 @@ void write_register(uint64_t offset, reg_intf_dw data, uint8_t num_bytes) {
     // Pre-compute access range and lock status based on format type
     #if (SRCMD_FMT == 0)
         srcmd_tbl_access = IS_IN_RANGE(offset, SRCMD_TABLE_BASE_OFFSET, SRCMD_TABLE_BASE_OFFSET + (IOPMP_RRID_NUM * SRCMD_REG_STRIDE) + 28);
-        is_srcmd_locked  = g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_en.l;
+        if (srcmd_tbl_access) {
+            is_srcmd_locked = g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_en.l;
+        }
 
     #elif (SRCMD_FMT == 2)
         srcmd_tbl_access = IS_IN_RANGE(offset, SRCMD_TABLE_BASE_OFFSET, SRCMD_TABLE_BASE_OFFSET + (IOPMP_MD_NUM * SRCMD_REG_STRIDE) + 8);
-        int table_index  = SRCMD_TABLE_INDEX(offset);
+        if (srcmd_tbl_access) {
+            int table_index = SRCMD_TABLE_INDEX(offset);
 
-        if (table_index < 31) {
-            is_srcmd_locked = (g_reg_file.mdlck.md >> table_index) & 1;
-        } else {
-            is_srcmd_locked = (g_reg_file.mdlckh.mdh >> (table_index - 31)) & 1;
+            if (table_index < 31) {
+                is_srcmd_locked = (g_reg_file.mdlck.md >> table_index) & 1;
+            } else {
+                is_srcmd_locked = (g_reg_file.mdlckh.mdh >> (table_index - 31)) & 1;
+            }
         }
     #endif
 

--- a/iopmp_ref_model/src/iopmp_reg.c
+++ b/iopmp_ref_model/src/iopmp_reg.c
@@ -654,16 +654,16 @@ void write_register(uint64_t offset, reg_intf_dw data, uint8_t num_bytes) {
 
 // Code block for handling SRCMD table accesses based on format type
 #if (SRCMD_FMT != 1)
-    int srcmd_tlb_access;
+    int srcmd_tbl_access;
     int is_srcmd_locked = 0;  // Initialize as unlocked
 
     // Pre-compute access range and lock status based on format type
     #if (SRCMD_FMT == 0)
-        srcmd_tlb_access = IS_IN_RANGE(offset, SRCMD_TABLE_BASE_OFFSET, SRCMD_TABLE_BASE_OFFSET + (IOPMP_RRID_NUM * SRCMD_REG_STRIDE) + 28);
+        srcmd_tbl_access = IS_IN_RANGE(offset, SRCMD_TABLE_BASE_OFFSET, SRCMD_TABLE_BASE_OFFSET + (IOPMP_RRID_NUM * SRCMD_REG_STRIDE) + 28);
         is_srcmd_locked  = g_reg_file.srcmd_table[SRCMD_TABLE_INDEX(offset)].srcmd_en.l;
 
     #elif (SRCMD_FMT == 2)
-        srcmd_tlb_access = IS_IN_RANGE(offset, SRCMD_TABLE_BASE_OFFSET, SRCMD_TABLE_BASE_OFFSET + (IOPMP_MD_NUM * SRCMD_REG_STRIDE) + 8);
+        srcmd_tbl_access = IS_IN_RANGE(offset, SRCMD_TABLE_BASE_OFFSET, SRCMD_TABLE_BASE_OFFSET + (IOPMP_MD_NUM * SRCMD_REG_STRIDE) + 8);
         int table_index  = SRCMD_TABLE_INDEX(offset);
 
         if (table_index < 31) {
@@ -674,7 +674,7 @@ void write_register(uint64_t offset, reg_intf_dw data, uint8_t num_bytes) {
     #endif
 
     // Proceed only if within access range and not locked
-    if (srcmd_tlb_access && !is_srcmd_locked) {
+    if (srcmd_tbl_access && !is_srcmd_locked) {
         uint32_t srcmd_reg = SRCMD_REG_INDEX(offset);
 
         switch (srcmd_reg) {

--- a/iopmp_ref_model/src/iopmp_reg.c
+++ b/iopmp_ref_model/src/iopmp_reg.c
@@ -382,7 +382,9 @@ void write_register(uint64_t offset, reg_intf_dw data, uint8_t num_bytes) {
     entrylck_t       entrylck_temp       = { .raw = upr_data4 };
     err_cfg_t        err_cfg_temp        = { .raw = lwr_data4 };
     entry_addr_t     entry_addr_temp     = { .raw = lwr_data4 };
+#if (IOPMP_ADDRH_EN)
     entry_addrh_t    entry_addrh_temp    = { .raw = upr_data4 };
+#endif
     entry_cfg_t      entry_cfg_temp      = { .raw = lwr_data4 };
     entry_user_cfg_t entry_user_cfg_temp = { .raw = upr_data4 };
 
@@ -394,7 +396,9 @@ void write_register(uint64_t offset, reg_intf_dw data, uint8_t num_bytes) {
 // Conditional block for msi addr
 #if (MSI_EN)
     err_msiaddr_t    err_msiaddr_temp    = { .raw = lwr_data4 };
+#if (IOPMP_ADDRH_EN)
     err_msiaddrh_t   err_msiaddrh_temp   = { .raw = upr_data4 };
+#endif
 #endif
 
 // Conditional block for SRCMD format

--- a/iopmp_ref_model/src/iopmp_validate.c
+++ b/iopmp_ref_model/src/iopmp_validate.c
@@ -130,7 +130,7 @@ void iopmp_validate_access(iopmp_trans_req_t *trans_req, iopmp_trans_rsp_t* iopm
         #endif
 
         for (int cur_entry = lwr_entry; cur_entry <= upr_entry; cur_entry++) {
-            uint64_t prev_addr     = CONCAT32(iopmp_entries.entry_table[cur_entry - 1].entry_addrh.addrh, iopmp_entries.entry_table[cur_entry - 1].entry_addr.addr);
+            uint64_t prev_addr     = (cur_entry == 0) ? 0 : CONCAT32(iopmp_entries.entry_table[cur_entry - 1].entry_addrh.addrh, iopmp_entries.entry_table[cur_entry - 1].entry_addr.addr);
             uint64_t curr_addr     = CONCAT32(iopmp_entries.entry_table[cur_entry].entry_addrh.addrh, iopmp_entries.entry_table[cur_entry].entry_addr.addr);
             entry_cfg_t entry_cfg  = iopmp_entries.entry_table[cur_entry].entry_cfg;
             bool is_priority_entry = (cur_entry < g_reg_file.hwcfg2.prio_entry);

--- a/iopmp_ref_model/src/iopmp_validate.c
+++ b/iopmp_ref_model/src/iopmp_validate.c
@@ -12,7 +12,9 @@
 
 iopmp_regs_t    g_reg_file;
 iopmp_entries_t iopmp_entries;
+#if (IOPMP_MFR_EN)
 err_mfrs_t      err_svs;
+#endif
 int             intrpt_suppress;
 int             error_suppress;
 int             stall_cntr;

--- a/iopmp_ref_model/verif/tests/compactmodel.c
+++ b/iopmp_ref_model/verif/tests/compactmodel.c
@@ -494,6 +494,7 @@ int main () {
    CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
    END_TEST();
 
+#if (IOPMP_MFR_EN)
    START_TEST("Test MFR Extension");
    receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
    // Entry Table CFG
@@ -518,6 +519,7 @@ int main () {
    FAIL_IF((err_mfr_temp.svw != 4));
    write_register(ERR_INFO_OFFSET,   0, 4);
    END_TEST();
+#endif
 
    START_TEST("Test Interrupt Suppression is Enabled");
    reset_iopmp();

--- a/iopmp_ref_model/verif/tests/compactmodel.c
+++ b/iopmp_ref_model/verif/tests/compactmodel.c
@@ -669,7 +669,11 @@ int main () {
     reset_iopmp();
     bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
     configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
@@ -688,7 +692,11 @@ int main () {
     START_TEST("Test MSI");
     reset_iopmp();
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
     configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);

--- a/iopmp_ref_model/verif/tests/dynamicmodel.c
+++ b/iopmp_ref_model/verif/tests/dynamicmodel.c
@@ -666,7 +666,7 @@ int main () {
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
-
+#if (IOPMP_MFR_EN)
     START_TEST("Test MFR Extension");
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
@@ -692,6 +692,7 @@ int main () {
     FAIL_IF((err_mfr_temp.svw != 4));
     write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test MDLCK, updating locked srcmd_enh field");
     reset_iopmp();

--- a/iopmp_ref_model/verif/tests/dynamicmodel.c
+++ b/iopmp_ref_model/verif/tests/dynamicmodel.c
@@ -931,7 +931,11 @@ int main () {
     reset_iopmp();
     bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);
@@ -952,7 +956,11 @@ int main () {
     START_TEST("Test MSI");
     reset_iopmp();
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);

--- a/iopmp_ref_model/verif/tests/fullmodel.c
+++ b/iopmp_ref_model/verif/tests/fullmodel.c
@@ -1008,7 +1008,11 @@ int main () {
     reset_iopmp();
     bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
@@ -1030,7 +1034,11 @@ int main () {
     START_TEST("Test MSI");
     reset_iopmp();
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);

--- a/iopmp_ref_model/verif/tests/fullmodel.c
+++ b/iopmp_ref_model/verif/tests/fullmodel.c
@@ -730,7 +730,7 @@ int main () {
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
-
+#if (IOPMP_MFR_EN)
     START_TEST("Test MFR Extension");
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
@@ -756,6 +756,7 @@ int main () {
     FAIL_IF((err_mfr_temp.svw != 4));
     write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test MDLCK, updating locked srcmd_enh field");
     reset_iopmp();

--- a/iopmp_ref_model/verif/tests/isolationmodel.c
+++ b/iopmp_ref_model/verif/tests/isolationmodel.c
@@ -711,7 +711,11 @@ int main () {
     reset_iopmp();
     bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_mdcfg_n(2, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
@@ -731,7 +735,11 @@ int main () {
     START_TEST("Test MSI");
     reset_iopmp();
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_mdcfg_n(2, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);

--- a/iopmp_ref_model/verif/tests/isolationmodel.c
+++ b/iopmp_ref_model/verif/tests/isolationmodel.c
@@ -491,7 +491,7 @@ int main () {
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
-
+#if (IOPMP_MFR_EN)
     START_TEST("Test MFR Extension");
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
@@ -515,6 +515,7 @@ int main () {
     FAIL_IF((err_mfr_temp.svw != 4));
     write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test Interrupt Suppression is Enabled");
     reset_iopmp();

--- a/iopmp_ref_model/verif/tests/rapidmodel.c
+++ b/iopmp_ref_model/verif/tests/rapidmodel.c
@@ -934,7 +934,11 @@ int main () {
     reset_iopmp();
     bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);
@@ -955,7 +959,11 @@ int main () {
     START_TEST("Test MSI");
     reset_iopmp();
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_ENH, 2, 0x1, 4);
     configure_srcmd_n(SRCMD_RH, 2, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, ((IOPMP_MD_ENTRY_NUM + 1) * 31), 90, 4);

--- a/iopmp_ref_model/verif/tests/rapidmodel.c
+++ b/iopmp_ref_model/verif/tests/rapidmodel.c
@@ -668,7 +668,7 @@ int main () {
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
-
+#if (IOPMP_MFR_EN)
     START_TEST("Test MFR Extension");
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
@@ -694,6 +694,7 @@ int main () {
     FAIL_IF((err_mfr_temp.svw != 4));
     write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test MDLCK, updating locked srcmd_enh field");
     reset_iopmp();

--- a/iopmp_ref_model/verif/tests/unnamed_model_1.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_1.c
@@ -488,6 +488,7 @@ int main () {
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
+#if (IOPMP_MFR_EN)
     START_TEST("Test MFR Extension");
     receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // Entry Table CFG
@@ -512,6 +513,7 @@ int main () {
     FAIL_IF((err_mfr_temp.svw != 4));
     write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test Interrupt Suppression is Enabled");
    reset_iopmp();

--- a/iopmp_ref_model/verif/tests/unnamed_model_1.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_1.c
@@ -664,7 +664,11 @@ int main () {
     reset_iopmp();
     bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
     configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);
@@ -683,7 +687,11 @@ int main () {
     START_TEST("Test MSI");
     reset_iopmp();
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     receiver_port(2, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     configure_entry_n(ENTRY_ADDR, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), 90, 4);
     configure_entry_n(ENTRY_CFG, (iopmp_trans_req.rrid * (IOPMP_MD_ENTRY_NUM + 1)), (NAPOT|R), 4);

--- a/iopmp_ref_model/verif/tests/unnamed_model_2.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_2.c
@@ -518,7 +518,7 @@ int main () {
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
-
+#if (IOPMP_MFR_EN)
     START_TEST("Test MFR Extension");
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
@@ -543,6 +543,7 @@ int main () {
     FAIL_IF((err_mfr_temp.svw != 4));
     write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test Interrupt Suppression is Enabled");
     reset_iopmp();

--- a/iopmp_ref_model/verif/tests/unnamed_model_2.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_2.c
@@ -749,7 +749,11 @@ int main () {
     reset_iopmp();
     bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
@@ -770,7 +774,11 @@ int main () {
     START_TEST("Test MSI");
     reset_iopmp();
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_mdcfg_n(31, 2, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);

--- a/iopmp_ref_model/verif/tests/unnamed_model_3.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_3.c
@@ -642,7 +642,11 @@ int main () {
     reset_iopmp();
     bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
@@ -662,7 +666,11 @@ int main () {
     START_TEST("Test MSI");
     reset_iopmp();
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);

--- a/iopmp_ref_model/verif/tests/unnamed_model_3.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_3.c
@@ -421,6 +421,7 @@ int main () {
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
+#if (IOPMP_MFR_EN)
     START_TEST("Test MFR Extension");
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
@@ -444,6 +445,7 @@ int main () {
     FAIL_IF((err_mfr_temp.svw != 4));
     write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test Interrupt Suppression is Enabled");
     reset_iopmp();

--- a/iopmp_ref_model/verif/tests/unnamed_model_4.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_4.c
@@ -622,7 +622,11 @@ int main () {
     reset_iopmp();
     bus_error = 0x8000;
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT | R), 4);
@@ -642,7 +646,11 @@ int main () {
     START_TEST("Test MSI");
     reset_iopmp();
     write_register(ERR_OFFSET, 0x8F0A, 4);
+#if (IOPMP_ADDRH_EN)
     write_register(ERR_MSIADDR_OFFSET, 0x8000, 4);
+#else
+    write_register(ERR_MSIADDR_OFFSET, (0x8000 >> 2), 4);
+#endif
     configure_srcmd_n(SRCMD_PERM, 31, 0x1, 4);
     configure_entry_n(ENTRY_ADDR, 1, 90, 4);
     configure_entry_n(ENTRY_CFG, 1, (NAPOT|R), 4);

--- a/iopmp_ref_model/verif/tests/unnamed_model_4.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_4.c
@@ -402,6 +402,7 @@ int main () {
     CHECK_IOPMP_TRANS(IOPMP_ERROR, NOT_HIT_ANY_RULE);
     END_TEST();
 
+#if (IOPMP_MFR_EN)
     START_TEST("Test MFR Extension");
     write_register(ENTRYLCK_OFFSET,   0x8, 4);   // ENTRY[0]-ENTRY[3] are locked
     write_register(ENTRYLCK_OFFSET,   0x1, 4);   // ENTRYLCK is locked
@@ -425,6 +426,7 @@ int main () {
     FAIL_IF((err_mfr_temp.svw != 4));
     write_register(ERR_INFO_OFFSET,   0, 4);
     END_TEST();
+#endif
 
     START_TEST("Test Interrupt Suppression is Enabled");
     reset_iopmp();


### PR DESCRIPTION
1. Conditionally build `ERR_MFR` register into the model only if `IOPMP_MFR_EN=1`.
2. Avoid declaring `ENTRY_ADDRH` and `ERR_MSIADDRH` if the configurations `IOPMP_ADDRH_EN=0` to fix compile errors.
3. When `HWCFG0.addrh_en=0`, the `ERR_MSIADDR` contains bits 33 to 2 of the MSI address. Fix the corresponding writing values in the test cases.
4. Fix bit mask of "md" field in `SRCMD` table and `MDSTALL` registers.
5. Rename `srcmd_tlb_access` to `srcmd_tbl_access`
6. Introduce AddressSanitizer compiler flags
7. Fix out-of-bounds access on `entry_table` array
8. Fix out-of-bounds access on `srcmd_table` array