### PR TITLE
Reference Model: Fix incorrect entry table lookup

### DIFF
--- a/iopmp_ref_model/src/iopmp_validate.c
+++ b/iopmp_ref_model/src/iopmp_validate.c
@@ -121,7 +121,7 @@ void iopmp_validate_access(iopmp_dev_t *iopmp, iopmp_trans_req_t *trans_req, iop
             upr_entry = ((cur_md + 1) * (iopmp->reg_file.hwcfg3.md_entry_num + 1));
         #endif
 
-        for (int cur_entry = lwr_entry; cur_entry <= upr_entry; cur_entry++) {
+        for (int cur_entry = lwr_entry; cur_entry < upr_entry; cur_entry++) {
             uint64_t prev_addr     = (cur_entry == 0) ? 0 : CONCAT32(iopmp->iopmp_entries.entry_table[cur_entry - 1].entry_addrh.addrh, iopmp->iopmp_entries.entry_table[cur_entry - 1].entry_addr.addr);
             uint64_t curr_addr     = CONCAT32(iopmp->iopmp_entries.entry_table[cur_entry].entry_addrh.addrh, iopmp->iopmp_entries.entry_table[cur_entry].entry_addr.addr);
             entry_cfg_t entry_cfg  = iopmp->iopmp_entries.entry_table[cur_entry].entry_cfg;


### PR DESCRIPTION
The MDCFG Table is used to map a memory domain to its own entries:
* For baseline MDCFG format:
  - index j belongs to MD m if MDCFG(m-1).t ≤ j < MDCFG(m).t, where m > 0.
  - index j belongs to MD 0 if j < MDCFG(0).t
* For other MDCFG formats:
  - Entry Indexes = [m * k, (m * k) + k - 1], where k=(HWCFG3.md_entry_num+1).

This commits fixes the bug in the reference model where upper bound index must not be iterated.