### PR TITLE
Reference Model: Fix typo of RRIDSCP_OFFSET

### DIFF
--- a/iopmp_ref_model/include/iopmp_registers.h
+++ b/iopmp_ref_model/include/iopmp_registers.h
@@ -27,7 +27,7 @@
 #define ENTRYOFFSET_OFFSET    0x2C
 #define MDSTALL_OFFSET        0x30
 #define MDSTALLH_OFFSET       0x34
-#define RRISCP_OFFSET         0x38
+#define RRIDSCP_OFFSET        0x38
 #define MDLCK_OFFSET          0x40
 #define MDLCKH_OFFSET         0x44
 #define MDCFGLCK_OFFSET       0x48

--- a/iopmp_ref_model/src/iopmp_reg.c
+++ b/iopmp_ref_model/src/iopmp_reg.c
@@ -394,7 +394,7 @@ void write_register(iopmp_dev_t *iopmp, uint64_t offset, reg_intf_dw data, uint8
         }
         break;
 
-    case RRISCP_OFFSET:
+    case RRIDSCP_OFFSET:
         if (iopmp->imp_rridscp) {
             iopmp->reg_file.rridscp.rsv  = 0;
             iopmp->reg_file.rridscp.op   = rridscp_temp.op;

--- a/iopmp_ref_model/verif/tests/compactmodel.c
+++ b/iopmp_ref_model/verif/tests/compactmodel.c
@@ -681,12 +681,12 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), (NAPOT | X), 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x40, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
@@ -702,12 +702,12 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), (NAPOT | X), 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x40, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     CHECK_IOPMP_TRANS(&iopmp, IOPMP_ERROR, STALLED_TRANSACTION);

--- a/iopmp_ref_model/verif/tests/dynamicmodel.c
+++ b/iopmp_ref_model/verif/tests/dynamicmodel.c
@@ -846,13 +846,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 3), 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
@@ -869,13 +869,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 3), 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     CHECK_IOPMP_TRANS(&iopmp, IOPMP_ERROR, STALLED_TRANSACTION);

--- a/iopmp_ref_model/verif/tests/fullmodel.c
+++ b/iopmp_ref_model/verif/tests/fullmodel.c
@@ -927,13 +927,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, 1, (NAPOT | X), 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
@@ -951,13 +951,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, 1, (NAPOT | X), 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     CHECK_IOPMP_TRANS(&iopmp, IOPMP_ERROR, STALLED_TRANSACTION);

--- a/iopmp_ref_model/verif/tests/isolationmodel.c
+++ b/iopmp_ref_model/verif/tests/isolationmodel.c
@@ -641,13 +641,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x40, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
@@ -663,13 +663,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x40, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     CHECK_IOPMP_TRANS(&iopmp, IOPMP_ERROR, STALLED_TRANSACTION);

--- a/iopmp_ref_model/verif/tests/rapidmodel.c
+++ b/iopmp_ref_model/verif/tests/rapidmodel.c
@@ -848,13 +848,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 3), 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
@@ -871,13 +871,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, ((iopmp.reg_file.hwcfg3.md_entry_num + 1) * 3), 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     CHECK_IOPMP_TRANS(&iopmp, IOPMP_ERROR, STALLED_TRANSACTION);

--- a/iopmp_ref_model/verif/tests/unnamed_model_1.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_1.c
@@ -668,12 +668,12 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), (NAPOT | X), 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x40, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
@@ -689,12 +689,12 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, (iopmp_trans_req.rrid * (iopmp.reg_file.hwcfg3.md_entry_num + 1)), (NAPOT | X), 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x40, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     CHECK_IOPMP_TRANS(&iopmp, IOPMP_ERROR, STALLED_TRANSACTION);

--- a/iopmp_ref_model/verif/tests/unnamed_model_2.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_2.c
@@ -683,13 +683,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
@@ -706,13 +706,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     CHECK_IOPMP_TRANS(&iopmp, IOPMP_ERROR, STALLED_TRANSACTION);

--- a/iopmp_ref_model/verif/tests/unnamed_model_3.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_3.c
@@ -581,13 +581,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
@@ -603,13 +603,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     CHECK_IOPMP_TRANS(&iopmp, IOPMP_ERROR, STALLED_TRANSACTION);

--- a/iopmp_ref_model/verif/tests/unnamed_model_4.c
+++ b/iopmp_ref_model/verif/tests/unnamed_model_4.c
@@ -563,13 +563,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled != 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     write_register(&iopmp, ERR_INFO_OFFSET, 0, 4);
@@ -585,13 +585,13 @@ int main()
     configure_entry_n(&iopmp, ENTRY_CFG, 1, 0x1C, 4);
     set_hwcfg0_enable(&iopmp);
     write_register(&iopmp, MDSTALL_OFFSET, 0x10, 4);
-    write_register(&iopmp, RRISCP_OFFSET, 5, 4);
+    write_register(&iopmp, RRIDSCP_OFFSET, 5, 4);
     receiver_port(5, 360, 0, 3, INSTR_FETCH, 0, &iopmp_trans_req);
     // requestor Port Signals
     iopmp_validate_access(&iopmp, &iopmp_trans_req, &iopmp_trans_rsp, &intrpt);
     FAIL_IF((iopmp_trans_rsp.rrid_stalled == 1));
     rridscp_t rridscp_temp;
-    rridscp_temp.raw = read_register(&iopmp, RRISCP_OFFSET, 4);
+    rridscp_temp.raw = read_register(&iopmp, RRIDSCP_OFFSET, 4);
     FAIL_IF((rridscp_temp.stat != 1));
     FAIL_IF((iopmp_trans_rsp.rrid != 5));
     CHECK_IOPMP_TRANS(&iopmp, IOPMP_ERROR, STALLED_TRANSACTION);


### PR DESCRIPTION
The name of register is RRIDSCP not RRISCP.