### PR TITLE
Update GitHub Actions to requested versions

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -32,7 +32,7 @@
       steps:
         # Checkout the repository
         - name: Checkout repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             submodules: recursive
   
@@ -46,7 +46,7 @@
   
         # Upload the built PDF files as a single artifact
         - name: Upload Build Artifacts
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v6
           with:
             name: Build Artifacts
             path: ${{ github.workspace }}/build/*.pdf
@@ -54,7 +54,7 @@
   
         # Create Release
         - name: Create Release
-          uses: softprops/action-gh-release@v1
+          uses: softprops/action-gh-release@v2
           with:
             files: ${{ github.workspace }}/build/*.pdf
             tag_name: v${{ github.event.inputs.version }}


### PR DESCRIPTION
This updates GitHub Actions workflow references to the requested versions.

Targets:
- `actions/checkout` -> `v6`
- `actions/upload-artifact` -> `v6`
- `softprops/action-gh-release` -> `v2`
